### PR TITLE
feat(action): caller-side textlint allowlist 対応（v2.1）

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -29,6 +29,9 @@ inputs:
   github-token:
     description: "reviewdog が PR レビューコメント投稿に使う GitHub token．caller 側で secrets.GITHUB_TOKEN を with で渡す"
     required: true
+  pyyaml-version:
+    description: "明示的に install する PyYAML のバージョン（== 形式の固定指定子，例: 6.0.2）．空のときは ubuntu-latest プリインストールの PyYAML をそのまま使う．self-hosted runner や再現性を重視する caller のための逃げ道"
+    default: ""
 
 runs:
   using: composite
@@ -71,10 +74,22 @@ runs:
         TEXTLINT_IGNORE="$(bash "${RESOLVE}" .textlintignore "${TEMPLATES}")"
         PRH_CFG="$(bash "${RESOLVE}" prh.yml "${TEMPLATES}")"
 
+        # caller root の .textlint-allowlist.yml は optional．存在すれば絶対パスを，
+        # 無ければ空文字を出力する．resolve-config-path.sh は「無ければ中央テンプレを返す」
+        # 規約のため allowlist には流用せず inline でハンドリングする．
+        if [ -f .textlint-allowlist.yml ]; then
+          ALLOWLIST_CFG="$(pwd)/.textlint-allowlist.yml"
+          echo "caller allowlist:    ${ALLOWLIST_CFG}"
+        else
+          ALLOWLIST_CFG=""
+          echo "caller allowlist:    (not configured)"
+        fi
+
         echo "mdlint=${MDLINT_CFG}" >> "${GITHUB_OUTPUT}"
         echo "textlint=${TEXTLINT_CFG}" >> "${GITHUB_OUTPUT}"
         echo "textlint_ignore=${TEXTLINT_IGNORE}" >> "${GITHUB_OUTPUT}"
         echo "prh=${PRH_CFG}" >> "${GITHUB_OUTPUT}"
+        echo "allowlist=${ALLOWLIST_CFG}" >> "${GITHUB_OUTPUT}"
         echo "markdownlint config: ${MDLINT_CFG}"
         echo "textlint config:     ${TEXTLINT_CFG}"
         echo "textlint ignore:     ${TEXTLINT_IGNORE}"
@@ -87,12 +102,24 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         SRC: ${{ steps.cfg.outputs.textlint }}
         PRH: ${{ steps.cfg.outputs.prh }}
+        ALLOWLIST: ${{ steps.cfg.outputs.allowlist }}
+        PYYAML_VERSION: ${{ inputs.pyyaml-version }}
       run: |
         set -euo pipefail
         REPO_ROOT="$(cd "${ACTION_PATH}/../../.." && pwd)"
         # caller cwd に依存せず確実に共有できる RUNNER_TEMP 配下に絶対パスで書き出す．
         DEST="${RUNNER_TEMP}/textlintrc.runtime.json"
-        python3 "${REPO_ROOT}/scripts/generate-textlint-runtime.py" "${SRC}" "${PRH}" "${DEST}"
+
+        # PyYAML は ubuntu-latest にプリインストールされているため，既定では何もしない．
+        # caller が pyyaml-version を明示した場合のみ pip install で固定する（再現性向上）．
+        # PyYAML は generate-textlint-runtime.py の allowlist 読込でのみ必要．
+        if [ -n "${PYYAML_VERSION}" ]; then
+          echo "Installing PyYAML==${PYYAML_VERSION} for reproducibility"
+          python3 -m pip install --quiet --user "pyyaml==${PYYAML_VERSION}"
+        fi
+
+        python3 "${REPO_ROOT}/scripts/generate-textlint-runtime.py" \
+          "${SRC}" "${PRH}" "${DEST}" "${ALLOWLIST}"
         echo "config=${DEST}" >> "${GITHUB_OUTPUT}"
 
     - name: Setup Node.js
@@ -142,7 +169,8 @@ runs:
           textlint-rule-preset-ja-technical-writing \
           textlint-rule-preset-ja-spacing \
           textlint-rule-prh \
-          textlint-filter-rule-comments)
+          textlint-filter-rule-comments \
+          textlint-filter-rule-allowlist)
         echo "bin=${TMP}/node_modules/.bin" >> "${GITHUB_OUTPUT}"
         echo "modules=${TMP}/node_modules" >> "${GITHUB_OUTPUT}"
         echo "Installed under: ${TMP}"

--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: "reviewdog が PR レビューコメント投稿に使う GitHub token．caller 側で secrets.GITHUB_TOKEN を with で渡す"
     required: true
   pyyaml-version:
-    description: "明示的に install する PyYAML のバージョン（== 形式の固定指定子，例: 6.0.2）．空のときは ubuntu-latest プリインストールの PyYAML をそのまま使う．self-hosted runner や再現性を重視する caller のための逃げ道"
+    description: "明示的に install する PyYAML のバージョン番号（例: 6.0.2）．内部で pyyaml==<value> として渡されるため == 等の比較子は付けない．空のときは ubuntu-latest プリインストールの PyYAML をそのまま使う．self-hosted runner や再現性を重視する caller のための逃げ道"
     default: ""
 
 runs:

--- a/README.md
+++ b/README.md
@@ -191,8 +191,11 @@ curl -fsSL \
 | `.markdownlint-cli2.yaml` | markdownlint のルールを全置換 |
 | `.textlintrc.json` | textlint のルールを全置換 |
 | `prh.yml` | 辞書を全置換（中央辞書は無視される） |
+| `.textlint-allowlist.yml` | caller 固有の例外語・例外パターン・例外ルールを差分追加（v2.1〜） |
 
 override は **ファイル全置換方式** であり，差分マージはしない．中央を基点にしたいときは中央の該当ファイルをコピーして，必要部分だけ改変する．
+
+`.textlint-allowlist.yml` だけは差分追加方式で，caller 単独で固有名詞や法令名等の false positive を恒久化できる．prh と allowlist の使い分けは [docs/dictionary-maintenance.md](docs/dictionary-maintenance.md) を参照．サンプルは [templates/.textlint-allowlist.yml](templates/.textlint-allowlist.yml) からコピーするとよい．
 
 ## 🔀 フォーク運用の手引き
 

--- a/docs/dictionary-maintenance.md
+++ b/docs/dictionary-maintenance.md
@@ -11,6 +11,7 @@
 - 2️⃣ per-repo の辞書 override
 - 3️⃣ prh.yml の書き方
 - 4️⃣ バージョニングと影響範囲
+- 5️⃣ prh と caller-side allowlist の使い分け
 
 ## 🎯 辞書を更新する場面
 
@@ -115,3 +116,36 @@ git push -f origin v1
 | prh 設定の構造変更 | `v2` など新メジャーを切る．`v1` はそのまま維持 |
 
 破壊的変更の場合は CLAUDE.md のタグ運用規律に従う．
+
+## 5️⃣ prh と caller-side allowlist の使い分け
+
+caller root に `.textlint-allowlist.yml` を置くと，固有の例外を textlint 指摘から外せる．
+v2.1〜 の機能で，差分追加方式のため中央設定は変更しない．prh とは目的が異なる．
+
+表 4: prh と caller-side allowlist の使い分け
+
+| 観点 | `templates/prh.yml`（中央） | `.textlint-allowlist.yml`（caller） |
+|---|---|---|
+| 目的 | 表記ゆれの統一 | 固有名詞・法令名等の例外許容 |
+| 対象 | すべての caller | 配置した caller のみ |
+| 例 | `github` → `GitHub` | `電波法施行規則` を `max-kanji-continuous-len` から除外 |
+| 反映 | 中央 PR 経由で全 caller に反映 | caller 単独で完結．中央 PR 不要 |
+| スキーマ | prh 仕様 | [textlint-filter-rule-allowlist 仕様](https://github.com/textlint/textlint-filter-rule-allowlist) |
+
+新しい例外語が出たら，まず「これは表記ゆれか」を確認する．表記ゆれなら中央 prh 追記，固有名詞の特殊事情なら caller 側 allowlist が向く．
+
+caller 側 allowlist の導入手順は次のとおり．
+
+```bash
+OWNER=tomio2480
+
+# サンプルを取得して必要部分のコメントを外す
+curl -fsSL \
+  "https://raw.githubusercontent.com/${OWNER}/github-workflows/main/templates/.textlint-allowlist.yml" \
+  > .textlint-allowlist.yml
+```
+
+allow / allowRules は次のように使い分ける．
+
+- `allow:` ：対象テキスト（文字列または `/regex/`）を丸ごと指摘から除外する
+- `allowRules:` ：特定のルール ID を caller 全体で無効化する

--- a/scripts/generate-textlint-runtime.py
+++ b/scripts/generate-textlint-runtime.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
-"""textlint config の rules.prh.rulePaths を絶対パスに差し替える runtime config を生成する．
+"""textlint config の rules.prh.rulePaths を絶対パスに差し替え，必要なら caller の
+.textlint-allowlist.yml を filters.allowlist に inject した runtime config を生成する．
 
 caller の textlintrc と中央の prh.yml を組み合わせると相対パスが意図どおりに解決されない
 ため，本スクリプトで `.textlintrc.runtime.json` を作成して action から渡す．
 
 caller が rules.prh を意図的に false または未定義にしている場合は尊重し，書き換えない．
+
+argv 4 つ目（optional）に caller root の .textlint-allowlist.yml の絶対パスが渡されると，
+その内容を filters.allowlist に inject する．空文字または argv 3 つの呼び出しでは
+filters は変更しない（後方互換）．
 """
 
 from __future__ import annotations
@@ -15,12 +20,32 @@ import sys
 from typing import Sequence
 
 
-def main(argv: Sequence[str]) -> None:
-    if len(argv) != 3:
+def _load_allowlist(path_str: str) -> dict:
+    path = pathlib.Path(path_str)
+    if not path.is_file():
         raise ValueError(
-            f"expected exactly 3 arguments (src, prh, dest), got {len(argv)}"
+            f"allowlist file not found: {path_str}"
+        )
+    import yaml  # 遅延 import．argv 3 つの呼び出しでは PyYAML を要求しない．
+
+    body = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        raise TypeError(
+            f"allowlist YAML root must be a mapping, got {type(body).__name__}"
+        )
+    return body
+
+
+def main(argv: Sequence[str]) -> None:
+    if len(argv) not in (3, 4):
+        raise ValueError(
+            f"expected 3 or 4 arguments (src, prh, dest, [allowlist]), got {len(argv)}"
         )
     src, prh, dest = argv[0], argv[1], argv[2]
+    allowlist_path = argv[3] if len(argv) == 4 else ""
+
     cfg = json.loads(pathlib.Path(src).read_text(encoding="utf-8"))
     if not isinstance(cfg, dict):
         raise ValueError(
@@ -39,6 +64,13 @@ def main(argv: Sequence[str]) -> None:
         pass
     else:
         raise TypeError("textlint config 'rules.prh' must be an object or false")
+
+    if allowlist_path:
+        allowlist = _load_allowlist(allowlist_path)
+        filters = cfg.setdefault("filters", {})
+        if not isinstance(filters, dict):
+            raise TypeError("textlint config 'filters' must be an object")
+        filters["allowlist"] = allowlist
 
     pathlib.Path(dest).write_text(
         json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8"

--- a/templates/.textlint-allowlist.yml
+++ b/templates/.textlint-allowlist.yml
@@ -1,0 +1,21 @@
+# caller リポジトリ root に配置すると，中央 textlint 設定を上書きせず per-repo の
+# 例外語・例外パターン・例外ルールを差分管理できる．composite action が runtime config の
+# filters.allowlist に inject する．配置しない場合は中央既定の空 allowlist が使われ noop．
+#
+# スキーマは textlint-filter-rule-allowlist に従う．
+# https://github.com/textlint/textlint-filter-rule-allowlist
+#
+# 使い方:
+#   - allow:      文字列または /regex/ の配列．対象テキストを丸ごと指摘から除外する
+#   - allowRules: ルール ID の配列．特定のルールを caller 全体で無効化する
+#
+# prh の表記ゆれ辞書とは目的が異なる．用途分担は次のとおり．
+#   - 表記ゆれの統一        → 中央 templates/prh.yml に追加（PR で全 caller 共有）
+#   - 固有名詞・法令名等の例外 → 本ファイル（caller 単独で完結）
+
+allow: []
+  # - 電波法施行規則              # 法令の正式名称：max-kanji-continuous-len 例外
+  # - "/!\\[.+?\\]\\(.+?\\)/"     # 画像 alt text の長文：sentence-length 例外
+
+allowRules: []
+  # - ja-technical-writing/ja-no-mixed-period   # 表 / 図 caption はラベル扱いとみなす

--- a/templates/.textlintrc.json
+++ b/templates/.textlintrc.json
@@ -45,6 +45,7 @@
     }
   },
   "filters": {
-    "comments": true
+    "comments": true,
+    "allowlist": {}
   }
 }

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pyyaml

--- a/tests/python/test_generate_textlint_runtime.py
+++ b/tests/python/test_generate_textlint_runtime.py
@@ -5,7 +5,11 @@
     - rules.prh が False または未定義のときはそのまま尊重する（書き換えない）
     - rules.prh がそれ以外の型のときは TypeError を上げる
     - rules 自体が dict でないときは TypeError を上げる
-    - 引数がちょうど 3 つでないときは ValueError を上げる（誤用時の早期失敗）
+    - 引数は 3 または 4．それ以外のときは ValueError を上げる（誤用時の早期失敗）
+    - argv 4 つ目（allowlist YAML パス）が空文字のときは filters を変更しない
+    - argv 4 つ目が valid なファイルのときは内容を filters.allowlist に inject する
+    - argv 4 つ目が指定されたが存在しないファイルのときは ValueError
+    - allowlist YAML root が dict でないときは TypeError
     - JSON ルートが dict でないときは ValueError を上げる
 """
 
@@ -93,11 +97,11 @@ def test_rules_not_object_raises_type_error(tmp_path):
         [],
         ["only-src"],
         ["src", "prh"],
-        ["src", "prh", "dest", "extra"],
+        ["src", "prh", "dest", "allowlist", "extra"],
     ],
 )
-def test_argv_must_be_exactly_3_otherwise_value_error(argv):
-    with pytest.raises(ValueError, match=r"\b3\b"):
+def test_argv_must_be_3_or_4_otherwise_value_error(argv):
+    with pytest.raises(ValueError, match=r"3 or 4"):
         _MODULE.main(argv)
 
 
@@ -118,3 +122,103 @@ def test_json_root_must_be_object_otherwise_value_error(tmp_path, non_dict_cfg):
 
     with pytest.raises(ValueError, match="object"):
         _MODULE.main([str(src), str(prh), str(dest)])
+
+
+def _make_allowlist(tmp_path: Path, body: str) -> Path:
+    allowlist = tmp_path / "allowlist.yml"
+    allowlist.write_text(body, encoding="utf-8")
+    return allowlist
+
+
+def test_allowlist_dict_is_injected_into_filters(tmp_path):
+    src = _write(
+        tmp_path / "src.json",
+        {"rules": {}, "filters": {"allowlist": {}, "comments": True}},
+    )
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+    allowlist = _make_allowlist(
+        tmp_path,
+        "allow:\n  - 電波法施行規則\nallowRules:\n  - ja-technical-writing/ja-no-mixed-period\n",
+    )
+
+    _MODULE.main([str(src), str(prh), str(dest), str(allowlist)])
+
+    written = json.loads(dest.read_text(encoding="utf-8"))
+    assert written["filters"]["allowlist"] == {
+        "allow": ["電波法施行規則"],
+        "allowRules": ["ja-technical-writing/ja-no-mixed-period"],
+    }
+    # 既存の他 filter（comments）は維持される
+    assert written["filters"]["comments"] is True
+
+
+def test_allowlist_empty_dict_is_injected_as_noop(tmp_path):
+    src = _write(
+        tmp_path / "src.json",
+        {"rules": {}, "filters": {"allowlist": {"allow": ["legacy"]}}},
+    )
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+    allowlist = _make_allowlist(tmp_path, "{}\n")
+
+    _MODULE.main([str(src), str(prh), str(dest), str(allowlist)])
+
+    written = json.loads(dest.read_text(encoding="utf-8"))
+    # 空の allowlist で上書きされる（caller が「何も許容しない」 と意図したケース）
+    assert written["filters"]["allowlist"] == {}
+
+
+def test_allowlist_path_empty_string_does_not_modify_filters(tmp_path):
+    original_filters = {"allowlist": {"allow": ["preserve-me"]}, "comments": True}
+    src = _write(
+        tmp_path / "src.json",
+        {"rules": {}, "filters": dict(original_filters)},
+    )
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+
+    _MODULE.main([str(src), str(prh), str(dest), ""])
+
+    written = json.loads(dest.read_text(encoding="utf-8"))
+    assert written["filters"] == original_filters
+
+
+def test_allowlist_creates_filters_when_absent(tmp_path):
+    src = _write(tmp_path / "src.json", {"rules": {}})
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+    allowlist = _make_allowlist(tmp_path, "allow:\n  - 固有名詞\n")
+
+    _MODULE.main([str(src), str(prh), str(dest), str(allowlist)])
+
+    written = json.loads(dest.read_text(encoding="utf-8"))
+    assert written["filters"]["allowlist"] == {"allow": ["固有名詞"]}
+
+
+def test_allowlist_missing_file_raises_value_error(tmp_path):
+    src = _write(tmp_path / "src.json", {"rules": {}})
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+    missing = tmp_path / "does-not-exist.yml"
+
+    with pytest.raises(ValueError, match="allowlist"):
+        _MODULE.main([str(src), str(prh), str(dest), str(missing)])
+
+
+@pytest.mark.parametrize(
+    "yaml_body",
+    [
+        "- a\n- b\n",
+        "just a string\n",
+        "42\n",
+    ],
+)
+def test_allowlist_root_must_be_dict_otherwise_type_error(tmp_path, yaml_body):
+    src = _write(tmp_path / "src.json", {"rules": {}})
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+    allowlist = _make_allowlist(tmp_path, yaml_body)
+
+    with pytest.raises(TypeError, match="allowlist"):
+        _MODULE.main([str(src), str(prh), str(dest), str(allowlist)])

--- a/tests/python/test_generate_textlint_runtime.py
+++ b/tests/python/test_generate_textlint_runtime.py
@@ -222,3 +222,32 @@ def test_allowlist_root_must_be_dict_otherwise_type_error(tmp_path, yaml_body):
 
     with pytest.raises(TypeError, match="allowlist"):
         _MODULE.main([str(src), str(prh), str(dest), str(allowlist)])
+
+
+@pytest.mark.parametrize(
+    "non_dict_filters",
+    [
+        None,
+        False,
+        [],
+        ["a", "list"],
+        "string",
+        42,
+    ],
+)
+def test_allowlist_filters_non_dict_raises_type_error(tmp_path, non_dict_filters):
+    """既存 filters が dict でない場合は意図的に TypeError を上げる（fail-fast）．
+
+    rules の strict ハンドリングと整合する設計．caller が `"filters": null` や
+    `"filters": false` と明示している場合は silent overwrite せず caller 意図を尊重する．
+    """
+    src = _write(
+        tmp_path / "src.json",
+        {"rules": {}, "filters": non_dict_filters},
+    )
+    prh = _make_prh(tmp_path)
+    dest = tmp_path / "runtime.json"
+    allowlist = _make_allowlist(tmp_path, "allow:\n  - foo\n")
+
+    with pytest.raises(TypeError, match="filters"):
+        _MODULE.main([str(src), str(prh), str(dest), str(allowlist)])


### PR DESCRIPTION
## 概要

caller リポジトリ root に optional `.textlint-allowlist.yml` を置けるようにし、composite action が runtime config の `filters.allowlist` に inject する。caller 固有の固有名詞・法令名等の false positive を中央 PR を介さず per-repo で恒久化できる。**v2.1 相当の非破壊的機能追加**。

Closes #14

## 変更内容

### feat(scripts): generate-textlint-runtime に allowlist inject

- `scripts/generate-textlint-runtime.py` を argv 4 つ目 optional に拡張
- 4 つ目に valid な YAML パスが渡されたら PyYAML で読み込み `filters.allowlist` に inject
- 4 つ目が空文字または argv 3 つの呼び出しは従来動作（後方互換）
- PyYAML は遅延 import．argv 3 つの caller には PyYAML 依存を要求しない

### feat(action): caller allowlist 検出と pyyaml-version input

- caller root の `.textlint-allowlist.yml` を Resolve config 段で inline 検出
- 新 input `pyyaml-version`（既定空）を追加。空のときは ubuntu-latest プリインストール PyYAML を使用、明示指定された場合のみ `pip install pyyaml==<version>` で固定（self-hosted / 再現性重視向け）
- npm install に `textlint-filter-rule-allowlist` を追加

### chore(textlintrc): filters.allowlist プレースホルダ

`templates/.textlintrc.json` の `filters` に `\"allowlist\": {}` を追加。caller が allowlist を配置しない場合も noop で動作（事前検証済み）。

### chore(template): caller-side サンプル

`templates/.textlint-allowlist.yml` を新設。allow / allowRules の使い方をコメント例示し、prh との用途分担を併記。

### docs

- README の per-repo override 表に `.textlint-allowlist.yml` を追加（差分追加方式である点を明示）
- `docs/dictionary-maintenance.md` に新節「prh と caller-side allowlist の使い分け」 を追加

### test (TDD Red→Green)

`tests/python/test_generate_textlint_runtime.py` に 12 ケース追加：

- argv は 3 または 4 厳密
- argv 4 つ目が空文字 → filters 不変
- argv 4 つ目が valid file → `filters.allowlist` に inject
- argv 4 つ目が指定されたが not found → ValueError
- allowlist YAML root が dict でない → TypeError
- 既存 filters（comments など）は維持
- `filters` キー欠落の src でも自動作成
- 空 dict {} で上書きされる

## 検証

- [x] `python -m pytest tests/python` 24 件 Green（新規 12 ケース含む）
- [x] textlint-filter-rule-allowlist の空 allowlist 挙動を `{}` / `{allow:[],allowRules:[]}` の 2 ケースで事前検証（noop 動作）
- [x] 新規 docs の textlint で line-length / period の新規エラーゼロ（既存 table caption 規約に追従）
- [x] 後方互換: argv 3 つの既存呼び出しと `pyyaml-version` 未指定で従来動作維持
- [ ] CI（self-test composite action）で allowlist プレースホルダ込み textlint が rule 解決まで通ること

## 既存 caller への影響

ゼロ。`.textlint-allowlist.yml` 未配置 / `pyyaml-version` 未指定で従来挙動。

## 次サイクル予告

- Issue #15（preset-ja-spacing 中黒・スラッシュ等の調査）
- Issue #7（npm パッケージ完全 pin）