### PR TITLE
docs: README/docs を最新化し開発知見を development-notes.md にまとめる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,4 @@
 - [docs/architecture.md](docs/architecture.md) — 内部動作と自己検出ロジック
 - [docs/security.md](docs/security.md) — 公開運用時の脅威モデル
 - [docs/fork-usage.md](docs/fork-usage.md) — フォーク利用手順
+- [docs/development-notes.md](docs/development-notes.md) — 設計判断とレビュー対応の知見（過去 PR のふりかえり）

--- a/README.md
+++ b/README.md
@@ -44,29 +44,34 @@ github-workflows/
 │   ├── workflows/
 │   │   └── test-self-lint.yml  # 単体／統合テスト用 CI workflow
 │   └── dependabot.yml          # third-party action の自動更新
-├── scripts/                    # composite action から呼ぶ抽出ロジック（test-first 対象）
+├── scripts/                       # composite action から呼ぶ抽出ロジック（test-first 対象）
+│   ├── add-pr-reaction.sh         # 👀 reaction 付与（fail-open）
 │   ├── generate-textlint-runtime.py
 │   └── resolve-config-path.sh
-├── tests/                      # スクリプト単体テスト + 統合テスト fixture
-│   ├── python/                 # pytest
-│   ├── bash/                   # bats-core
-│   └── fixtures/markdown/      # 統合テスト用 Markdown
-├── templates/                  # 各リポジトリにコピーするテンプレート
+├── tests/                         # スクリプト単体テスト + 統合テスト fixture
+│   ├── python/                    # pytest
+│   ├── bash/                      # bats-core
+│   └── fixtures/markdown/         # 統合テスト用 Markdown
+├── templates/                     # 各リポジトリにコピーするテンプレート
 │   ├── .github/
 │   │   └── workflows/
-│   │       └── md-lint.yml     # 呼び出し側ワークフロー（唯一の必須ファイル）
-│   ├── .markdownlint-cli2.yaml # 中央デフォルト＋override 用
-│   ├── .textlintrc.json        # 中央デフォルト＋override 用
-│   ├── prh.yml                 # 中央辞書＋override 用
-│   └── lefthook.yml            # ローカル hook（任意）
-├── docs/                       # 運用ガイド
+│   │       └── md-lint.yml        # 呼び出し側ワークフロー（唯一の必須ファイル）
+│   ├── .markdownlint-cli2.yaml    # 中央デフォルト＋override 用
+│   ├── .textlintrc.json           # 中央デフォルト＋override 用
+│   ├── .textlintignore            # 中央 ignore 設定＋override 用
+│   ├── .textlint-allowlist.yml    # caller-side allowlist のサンプル（v2.1〜，optional）
+│   ├── prh.yml                    # 中央辞書＋override 用
+│   └── lefthook.yml               # ローカル hook（任意）
+├── docs/                          # 運用ガイド
 │   ├── setup-guide.md
 │   ├── onboarding-new-repo.md
 │   ├── onboarding-existing-repo.md
 │   ├── dictionary-maintenance.md
+│   ├── rule-rationale.md
 │   ├── architecture.md
 │   ├── security.md
-│   └── fork-usage.md
+│   ├── fork-usage.md
+│   └── development-notes.md       # 設計判断とレビュー対応の知見
 ├── README.md
 ├── CLAUDE.md                   # AI エージェント向けの作業指針
 └── LICENSE
@@ -243,6 +248,7 @@ caller 固有の例外は per-repo override で吸収する前提とし，中央
 | [docs/architecture.md](docs/architecture.md) | 内部動作 | メンテナー・AI |
 | [docs/security.md](docs/security.md) | 公開運用の脅威モデル | オーナー |
 | [docs/fork-usage.md](docs/fork-usage.md) | フォーク運用 | 他利用者 |
+| [docs/development-notes.md](docs/development-notes.md) | 設計判断とレビュー対応の知見 | メンテナー・AI |
 
 ## 📝 ライセンス
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,8 +89,15 @@ action.yml は `.github/actions/markdown-lint/` に置かれているため，`$
 | `.textlintrc.json` | 同上 |
 | `.textlintignore` | 同上．textlint には `--ignore-path` で明示的に渡す |
 | `prh.yml` | 同上 |
+| `.textlint-allowlist.yml` | ① caller root に存在すれば絶対パスを採用 → ② 無ければ空文字（中央フォールバックを持たない optional ファイル．v2.1〜） |
 
 **ファイル全置換方式** のため，caller に置いたファイルは中央と差分マージされず単独で採用される．部分的に中央を流用したいときは中央の該当ファイルを丸ごとコピーしてから改変する．
+
+`.textlint-allowlist.yml` のみ規約から外れる．
+`scripts/resolve-config-path.sh` の「無ければ中央テンプレを返す」抽象には乗らない．
+そのため `action.yml` 内で `[ -f .textlint-allowlist.yml ]` を inline 判定する．
+存在すれば runtime config の `filters.allowlist` に inject される．
+無ければ中央 `templates/.textlintrc.json` 既定の `"allowlist": {}`（noop）が使われる．
 
 ### lint 対象外パターンと self-test
 
@@ -100,16 +107,31 @@ action.yml は `.github/actions/markdown-lint/` に置かれているため，`$
 
 ### textlint 用 runtime config 生成
 
-`.textlintrc.json` の `rules.prh.rulePaths` は相対パスで書かれている．中央の textlint config と caller の prh.yml（または逆）を組み合わせると相対解決が意図どおりにならない場合がある．
+`.textlintrc.json` の `rules.prh.rulePaths` は相対パスで書かれている．
+中央の textlint config と caller の prh.yml を組み合わせると相対解決が意図どおりにならない場合がある．
+加えて caller の `.textlint-allowlist.yml` を `filters.allowlist` に inject する責務もここで担う．
 
 このため workflow は次のステップを挟む．
 
 1. 解決済みの textlint config を読み込む
 2. `rules.prh.rulePaths` を解決済みの prh.yml の絶対パスで上書きする
-3. `.textlintrc.runtime.json` として caller root に書き出す
-4. textlint action にはこの runtime config を渡す
+3. caller root の `.textlint-allowlist.yml` があれば PyYAML で読み込み `filters.allowlist` を上書き．
+   無ければ中央既定の `"allowlist": {}`（noop）が残る
+4. `.textlintrc.runtime.json` として `RUNNER_TEMP` 配下に書き出す
+5. textlint コマンドにはこの runtime config を渡す
 
-これにより override 組み合わせ（caller 辞書＋中央 textlintrc など）でも path が破綻しない．
+allowlist の inject は `scripts/generate-textlint-runtime.py` で行う．
+argv 4 つ目（optional）で allowlist パスを受け取る．
+argv 3 つの呼び出しは従来動作を厳密維持する．
+PyYAML は遅延 import としており，3 つ呼び出しに依存追加を強要しない．
+
+PyYAML は `ubuntu-latest` runner に preinstall されている前提である．
+再現性が必要な caller は `pyyaml-version` input にバージョン番号（例 `6.0.2`）を渡せばよい．
+内部で `pip install pyyaml==<value>` として固定される．`==` 等の比較子は付けない．
+既定（空文字）では何も install せず runner 既定の PyYAML を使う．
+
+この組み立てにより，override 組み合わせ（caller 辞書＋中央 textlintrc など）でも path が破綻しない．
+caller 単独で固有名詞や法令名等の例外も差分追加できる．
 
 ## 👀 review 開始の可視化（PR reaction）
 

--- a/docs/development-notes.md
+++ b/docs/development-notes.md
@@ -1,0 +1,221 @@
+# 🧠 開発メモ
+
+## 要約
+
+本リポジトリの実装・レビューを通じて得た知見をまとめる．
+コード規律自体はリポジトリの [CLAUDE.md](../CLAUDE.md) と各自のグローバル設定に従う．
+本ドキュメントでは中央リポジトリ特有の設計判断を扱う．
+あわせて自動レビュー対応で繰り返し有効だったパターンも記録する．
+
+PR #16 と #17 の経験を主な題材としている．
+類似タスクに着手するセッションが過去判断を辿れるようにする．
+
+## 目次
+
+- 🧭 設計判断
+- 📜 文章・コードの規約要点
+- 🤖 自動レビュー対応のパターン
+- 🛠 ローカル検証ワークフロー
+- 🔁 PR push 後のポーリング運用
+- 📂 主な参照先
+
+## 🧭 設計判断
+
+### 機能追加は argv の optional 化と遅延 import で後方互換を保つ
+
+`scripts/generate-textlint-runtime.py` は当初 argv 3 つ厳格だった．
+PR #17 で 4 つ目に optional の allowlist パスを受け取る形に拡張している．
+要点は次のとおり．
+
+- 受け入れ条件は `len(argv) in (3, 4)` で fail-fast
+- 4 つ目が空文字または argv 3 つの呼び出しは従来動作を厳密維持
+- 4 つ目専用の依存（PyYAML）は **遅延 import** にして既存 caller に依存追加を強要しない
+
+caller の絶対多数は PR #17 以前の呼び出しを使う．
+新機能を opt-in にする設計を採っている．
+
+### 非 dict は silent overwrite せず TypeError で fail-fast
+
+`rules` および `filters` が dict でない場合は意図的に `TypeError` を上げる．
+PR #17 の Gemini review では「常に上書きする方が robust」という提案があった．
+以下の観点で却下している．
+
+- caller が `"filters": null` や `false` と書いた意図を silent overwrite で喪失するリスクが大きい
+- 既存 `rules` のハンドリングと整合し，スクリプト全体で fail-fast 原則が一貫する
+
+この strict 挙動は parametrize テストで pin 済である．
+具体例は `test_allowlist_filters_non_dict_raises_type_error` を参照．
+
+### 中央フォールバック有り / 無しでファイル検出ロジックを分ける
+
+caller の override 対象ファイルは中央テンプレに同名ファイルが必ず存在する．
+無ければ中央を使う規約のため `scripts/resolve-config-path.sh` で抽象化されている．
+
+一方で `.textlint-allowlist.yml` は中央フォールバックを持たない optional ファイル．
+`resolve-config-path.sh` には流用しない．
+`action.yml` 内で `[ -f .textlint-allowlist.yml ]` を inline 判定する．
+存在すれば絶対パスを，無ければ空文字を step output として渡す．
+
+### 外部ツール依存は preinstall 前提＋ caller opt-in 固定
+
+PyYAML は `ubuntu-latest` runner にプリインストール済のため，composite action の既定では何もしない．
+caller が再現性を重視する場合のみ `pyyaml-version` input にバージョン番号（例 `6.0.2`）を渡す．
+内部で `pip install pyyaml==<value>` として実行されるため，比較子の混入は厳禁．
+
+description で `==` 等の指定子混入を許すと `pyyaml====6.0.2` のような無効指定を生む．
+「バージョン番号のみ．== 等の比較子は付けない」と必ず明記する．
+
+## 📜 文章・コードの規約要点
+
+`templates/.textlintrc.json` の合算で次が必須となる．
+
+| 項目 | 設定 |
+|---|---|
+| 句点 | `．` （ja-no-mixed-period の periodMark） |
+| 1 文の長さ | 80 字以内（sentence-length max 80） |
+| 連続漢字 | 6 字以内（max-kanji-continuous-len max 6） |
+| 全角カッコ `（）` `「」` | 前後にも内側にも半角スペースを入れない（ja-no-space-around-parentheses） |
+| inline code span | 前後に半角スペース（ja-space-around-code） |
+| 強調 `**` | 開始の直前と終了の直後に半角スペース．内側にスペースは入れない |
+
+慣習として通っているもの（既存パターンに合わせる）．
+
+- table caption（`表 N: ...`）は句点を付けない
+- 助詞の前後に inline code を置く際は code span のスペース規則を優先する
+- 図がある場合は図番号と alt 相当の要約を直下または直前に書く
+
+Python テストの規約は次のとおり．
+
+- 関数 docstring は **書かない**．テスト名と module docstring で意図を表現する
+- `pytest.raises(..., match=...)` の `match` は具体的な部分一致を指定する
+- 引数のバリエーションは `@pytest.mark.parametrize` で網羅する
+- `tests/python/requirements.txt` は最小（`pytest`，必要に応じて `pyyaml`）
+
+CodeRabbit の Docstring Coverage 既定しきい値 80 % は本スタイルでは満たせない．
+テストファイル間の一貫性を優先する判断を採っている．
+
+## 🤖 自動レビュー対応のパターン
+
+### 採用 / 却下の判断軸
+
+| 指摘パターン | 既定方針 |
+|---|---|
+| 仕様・後方互換の盲点（quoted form / コメント付き形式 等） | 採用 |
+| description やコメントの誤読リスク指摘 | 採用 |
+| robustness を理由とした silent overwrite 提案 | 設計と整合するか確認．本リポジトリは fail-fast 採用 |
+| 既存パターンを 1 箇所だけ変える refactor | scope 外として follow-up issue 化 |
+| inline shell の抽出提案 | 規模を見て判断．glue 程度なら抽出しない |
+
+### 返信は決定と理由を明示する
+
+bot レビューでも，採用 / 却下の決定と理由を明文化して返信する．
+将来同様の指摘が来たときに過去の判断を辿るためのトレーサビリティになる．
+scope 外の指摘は follow-up issue を起票して返信本文にリンクする．
+具体例として PR #17 から Issue #18 を起票したケースがある．
+
+### 設計意図はテストで pin する
+
+「この挙動は意図的か？」という疑義が来るたびに「はい意図です」と答えるのは弱い．
+設計意図を示す parametrize テストを足し，将来の不用意な silent overwrite 化を機械的に防ぐ．
+
+PR #17 の `test_allowlist_filters_non_dict_raises_type_error` は具体例である．
+filters 非 dict ケースとして None / False / list 2 種 / string / int の 6 通りを網羅し pin した．
+
+### 構造アサーションでも TDD は成立する
+
+PR #16 の `test_templates_prh.py` は YAML をパースしていない．
+`templates/prh.yml` の生テキストを正規表現で走査する．
+bare `JS` パターンの不在と `/\bJS\b/` の存在をアサートしている．
+新規依存を増やさず Red→Green を回せた事例である．
+
+regex は最初 `^\s*-\s*JS\s*$` だったが，レビューで次の漏れが指摘された．
+
+- 末尾コメント `- JS  # 略称` 形式（Gemini）
+- YAML quoted form `- "JS"` / `- 'JS'`（CodeRabbit）
+
+最終形は `r"^\s*-\s*(?:['\"])?JS(?:['\"])?\s*(?:#.*)?\s*$"` となった．
+構造アサーションは依存を抑えられる代わりに **想定パターンの網羅** を意識する必要がある．
+
+## 🛠 ローカル検証ワークフロー
+
+ドキュメント変更を含む PR では，push 前に次を流すと CI レビューサイクルを節約できる．
+
+### Python ユニットテスト
+
+```bash
+python -m pytest tests/python -q
+```
+
+### textlint をローカルで再現
+
+`templates/.textlintrc.json` の `rules.prh.rulePaths` は相対パスである．
+ローカル実行時は絶対パスに差し替えた runtime config を作って渡す．
+
+```python
+import json, pathlib
+cfg = json.loads(pathlib.Path('templates/.textlintrc.json').read_text(encoding='utf-8'))
+cfg['rules']['prh']['rulePaths'] = [str(pathlib.Path('templates/prh.yml').resolve())]
+pathlib.Path('.textlintrc.runtime.json').write_text(
+    json.dumps(cfg, ensure_ascii=False, indent=2), encoding='utf-8'
+)
+```
+
+実行例は次のとおり．
+
+```bash
+npx --yes -p textlint@14 \
+    -p textlint-rule-preset-ja-technical-writing \
+    -p textlint-rule-preset-ja-spacing \
+    -p textlint-rule-prh \
+    -p textlint-filter-rule-comments \
+    -p textlint-filter-rule-allowlist \
+    -- textlint --config .textlintrc.runtime.json <対象ファイル>
+rm .textlintrc.runtime.json
+```
+
+### markdownlint をローカルで再現
+
+```bash
+npx --yes markdownlint-cli2 <対象ファイル>
+```
+
+ただし `markdownlint-cli2` の最新版は composite action 内蔵版と差がある．
+composite action は `reviewdog/action-markdownlint` を SHA pin している．
+新しい rule（例 MD060）が最新版で追加されていることがある．
+**新規エラーが自分の変更で発生したか既存 baseline かを切り分け**て扱う．
+迷ったら `git stash` で変更を退避して baseline を確認するとよい．
+
+## 🔁 PR push 後のポーリング運用
+
+bot レビュー（Gemini Code Assist / CodeRabbit）の到着には数分から十数分の幅がある．
+連続で push せず一拍おく狙いとして次の運用が有効である．
+
+1. push 直後に baseline を取得する
+
+    ```bash
+    gh api repos/<owner>/<repo>/pulls/<n>/comments --paginate > .pr_baseline.json
+    gh pr view <n> --json comments > .pr_top_baseline.json
+    ```
+
+2. Claude Agent SDK の `ScheduleWakeup` で初回 10 分後にチェック，以後 5 分ごとに polling
+3. baseline と diff して新規コメント検出時にループ終了
+
+`ScheduleWakeup` の自己再投入で polling は成立する．
+prompt にループ全文を渡せばよい．
+キャッシュ TTL の関係で 5 分間隔は厳密には非効率である．
+bot レビューは到着間隔が読めないため受容している．
+
+新規コメント検出後は次の順で対応する．
+
+1. 採用と却下を決め，理由をまとめる
+2. 採用分はローカルで修正＋テストして commit を分ける
+3. ユーザー承認 → push
+4. 全コメントに返信．scope 外の指摘は follow-up issue を起票してリンクで応答
+
+## 📂 主な参照先
+
+- リポジトリ性格と AI 作業規律: [CLAUDE.md](../CLAUDE.md)
+- アーキテクチャと自己検出ロジック: [docs/architecture.md](architecture.md)
+- 採用ルールの根拠: [docs/rule-rationale.md](rule-rationale.md)
+- 辞書と allowlist の使い分け: [docs/dictionary-maintenance.md](dictionary-maintenance.md)
+- 公開運用の脅威モデル: [docs/security.md](security.md)

--- a/docs/development-notes.md
+++ b/docs/development-notes.md
@@ -190,10 +190,12 @@ composite action は `reviewdog/action-markdownlint` を SHA pin している．
 bot レビュー（Gemini Code Assist / CodeRabbit）の到着には数分から十数分の幅がある．
 連続で push せず一拍おく狙いとして次の運用が有効である．
 
-1. push 直後に baseline を取得する
+1. push 直後に baseline を取得する．2 つは排他的に異なるコメント種別を返す
 
     ```bash
-    gh api repos/<owner>/<repo>/pulls/<n>/comments --paginate > .pr_baseline.json
+    # inline review comments（特定行に紐づくレビューコメント）
+    gh api repos/<owner>/<repo>/pulls/<n>/comments --paginate > .pr_inline_baseline.json
+    # top-level / issue-level comments（PR スレッド全体への投稿）
     gh pr view <n> --json comments > .pr_top_baseline.json
     ```
 

--- a/docs/rule-rationale.md
+++ b/docs/rule-rationale.md
@@ -24,7 +24,7 @@
 - データの整合性に資する
 
 caller 固有の例外は per-repo override で吸収する前提とし，中央側は「広く効く既定」を優先する方針である．
-個別 caller の例外語彙は将来的に [Issue #14](https://github.com/tomio2480/github-workflows/issues/14) の caller-side allowlist で扱う想定である．
+個別 caller の例外語彙は v2.1（[Issue #14](https://github.com/tomio2480/github-workflows/issues/14) で実装）以降，caller root に `.textlint-allowlist.yml` を置くことで扱える．運用方針は [docs/dictionary-maintenance.md](dictionary-maintenance.md) を参照．
 
 ## 🧩 ja-no-space-around-parentheses の根拠
 


### PR DESCRIPTION
## 概要

PR #11 / #16 / #17 を経て増えたファイル群と設計変更が README やアーキテクチャドキュメントに追従できていなかったため，齟齬を一括で解消する．あわせて今後類似タスクに着手するセッションが過去判断を辿れるよう，開発で得た知見を新規 `docs/development-notes.md` に集約する．

## 変更内容

### docs(readme): ディレクトリ構成と docs 一覧を最新化

- ディレクトリ構成図に `scripts/add-pr-reaction.sh`，`templates/.textlintignore`，`templates/.textlint-allowlist.yml`，`docs/rule-rationale.md` を追加
- ドキュメント一覧表に新規 `docs/development-notes.md` を登録

### docs(architecture): allowlist の解決と runtime inject を追記

- 表 3「解決対象ファイルと解決ロジック」 に `.textlint-allowlist.yml` を追加（中央フォールバック無し，optional の規約外）
- `action.yml` 内 inline 判定の理由と挙動を本文で補足
- 「textlint 用 runtime config 生成」 節に allowlist inject の責務，PyYAML 遅延 import，`pyyaml-version` input の扱いを追記

### docs(rule-rationale,claude): allowlist 実装済の言及に更新

- `rule-rationale.md`: Issue #14 を「将来扱う想定」 から「v2.1 で実装済」 に更新
- `CLAUDE.md`: 関連ドキュメント節に `development-notes.md` を登録

### docs: 開発で得た知見を development-notes.md にまとめる（新規）

PR #16（prh JS boundary + 採用根拠 docs）と PR #17（caller-side allowlist）の経験を体系化．

- 設計判断: argv optional 化＋遅延 import で後方互換，非 dict は fail-fast TypeError，中央フォールバック有り無しでファイル検出ロジックを分離，外部ツール依存は preinstall 前提＋ caller opt-in 固定
- 文章・コード規約要点（textlintrc 由来 / Python テストスタイル）
- 自動レビュー対応の判断軸と返信のトレーサビリティ，設計意図を test で pin する habit，構造アサーション TDD の事例
- ローカル検証ワークフロー（pytest / textlint runtime 生成スニペット / markdownlint）
- PR push 後の polling 運用（ScheduleWakeup の自己再投入）

## 検証

- [x] `pytest tests/python` 30 件 Green を維持（コード変更なし）
- [x] 新規・編集箇所の textlint 新規エラーゼロ（残るのは既存の prh substring match 既知問題のみ：`markdown` / `ユーザ` ．本 PR スコープ外）
- [x] 既存 textlint 違反箇所には触れていない（必要なら follow-up issue で扱う）

## 影響範囲

ドキュメントのみ．caller への動作影響なし．