### PR TITLE
refactor(action): action.yml のパス参照を ACTION_PATH 直接参照に統一

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -63,11 +63,10 @@ runs:
       run: |
         set -euo pipefail
         # action_path = .../.github/actions/markdown-lint
-        # repo root   = action_path/../../..
-        # templates   = repo root/templates
-        REPO_ROOT="$(cd "${ACTION_PATH}/../../.." && pwd)"
-        TEMPLATES="${REPO_ROOT}/templates"
-        RESOLVE="${REPO_ROOT}/scripts/resolve-config-path.sh"
+        # ${ACTION_PATH}/../../../templates / scripts でリポジトリルート起点に到達できる．
+        # OS 側で `..` セグメントが解決されるため cd/pwd で正規化する必要はない．
+        TEMPLATES="${ACTION_PATH}/../../../templates"
+        RESOLVE="${ACTION_PATH}/../../../scripts/resolve-config-path.sh"
 
         MDLINT_CFG="$(bash "${RESOLVE}" .markdownlint-cli2.yaml "${TEMPLATES}")"
         TEXTLINT_CFG="$(bash "${RESOLVE}" .textlintrc.json "${TEMPLATES}")"
@@ -106,7 +105,6 @@ runs:
         PYYAML_VERSION: ${{ inputs.pyyaml-version }}
       run: |
         set -euo pipefail
-        REPO_ROOT="$(cd "${ACTION_PATH}/../../.." && pwd)"
         # caller cwd に依存せず確実に共有できる RUNNER_TEMP 配下に絶対パスで書き出す．
         DEST="${RUNNER_TEMP}/textlintrc.runtime.json"
 
@@ -118,7 +116,7 @@ runs:
           python3 -m pip install --quiet --user "pyyaml==${PYYAML_VERSION}"
         fi
 
-        python3 "${REPO_ROOT}/scripts/generate-textlint-runtime.py" \
+        python3 "${ACTION_PATH}/../../../scripts/generate-textlint-runtime.py" \
           "${SRC}" "${PRH}" "${DEST}" "${ALLOWLIST}"
         echo "config=${DEST}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## 概要

`.github/actions/markdown-lint/action.yml` の `Resolve config file paths` と `Generate runtime textlint config` の 2 step で行っていた `REPO_ROOT="$(cd "${ACTION_PATH}/../../.." && pwd)"` の計算を削除し，`${ACTION_PATH}/../../../...` の直接参照に統一する．

reaction step（PR #11 で抽出）は元から直接参照スタイルを採用しており，本 PR で残る 2 step を揃える完了形になる．

PR #17 の Gemini Code Assist review で指摘されたパターンを，`action.yml` 全体に対して一括適用するために [Issue #18](https://github.com/tomio2480/github-workflows/issues/18) として起票した内容．

Closes #18

## 変更内容

- `Resolve config file paths` step: `REPO_ROOT` 計算を削除し，`TEMPLATES` と `RESOLVE` を `${ACTION_PATH}/../../../...` 直接参照に
- `Generate runtime textlint config` step: 同じく `REPO_ROOT` 計算を削除し，`generate-textlint-runtime.py` のパスを直接参照に

## 検証

- [x] `python -m pytest tests/python` 30 件 Green を維持（コード変更なし）
- [ ] CI（self-test composite action）で integration job まで通ることを確認

## 機能影響

なし．

- 出力ログから REPO_ROOT 行が消える程度の差
- パスに `..` セグメントが含まれるが OS で解決されるため file IO 的に等価
- caller / 既存テストへの影響ゼロ

## ドキュメント整合性

`docs/architecture.md` 表 2「自己検出で得られる値」 が既に `${GITHUB_ACTION_PATH}/../../../templates` 形式を「設計上の正」 として記載しており，本 PR は code を docs に追従させる位置付け．新規 docs 修正は不要．