### PR TITLE
docs: SemVer 風 patch tag 運用へ移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@
 ### テンプレート・設定ファイルの変更
 
 - `templates/prh.yml` などの中央デフォルト設定は，`@main` 直接参照の caller では即時反映される．SHA pin 利用者には Dependabot 更新 PR を経由して伝わる．破壊的追加（既存 caller で誤検出が増える恐れ）は注意
-- パッチ追随を opt-in する利用者向けに `v2.x.y` タグを切る場合は，影響確認と stakeholder 通知を行う
+- **PR マージごとに `vX.Y.Z` patch タグを切る**（patch 番号運用）．caller は `@v2.2.0` のような固定 patch を pin できる．immutable patch は GitHub Release を伴う
+- **major mutable タグ（`v2` 等）は最新 patch に追従させる**．PR マージ後に `git tag -f v2 <new-sha>` で進める．`@v2` pin 利用者は次回 PR で自動的に最新 patch を受け取る
 - 設定構造そのものの変更（既存 inputs の意味変更や required 化）は次の major version 相当として扱う
 - 変更は `docs/` の手順にも反映する．とくに [docs/architecture.md](docs/architecture.md) と [docs/dictionary-maintenance.md](docs/dictionary-maintenance.md) の記述が古くならないこと
 
@@ -53,7 +54,7 @@
 - `secrets: inherit` は使わない．必要な secret は個別に明示
 - third-party action は full commit SHA で参照
 - 外部からの PR を扱う場合は workflow・dependencies の変更を特に精査
-- `v1` などの共有タグを動かすときは事前に周知・影響範囲確認
+- 共有タグの運用：major mutable（`v2`）は patch リリースごとに進める方針．後方非互換を伴う場合は新 major（`v3`）を切り旧 major は据え置く．`v1` は self-detection bug により動作しないため移動しない
 
 ## ✅ コミット・PR ルール
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ github-workflows/
 | アップデート（`@main`） | 中央 main へのマージで次回 PR から即反映 | 自分でフォーク先に上流同期すると反映 |
 | おすすめ対象 | Tomio さん本人 / ルールに異存がない利用者 | 組織運用 / ルールを独自カスタムしたい利用者 |
 
-参照先（`@` 以降）は caller workflow で選ぶ．既定は `@<SHA> # v2.2.0` 形式の SHA pin で，Dependabot が SHA と patch バージョンを自動追随する．即時反映を優先したい場合は `@main` を，caller 自身で明示的に追従したい場合は `@v2`（major mutable，patch ごとに進む）または `@v2.2.0`（patch immutable）を pin する．`@v1` / `@v1.0.0` 系は self-detection bug により動作しないため利用しない．
+参照先（`@` 以降）は caller workflow で選ぶ．既定は `@<SHA> # v2.2.0` 形式の SHA pin で，Dependabot が SHA とバージョンを自動追随する．即時反映を優先したい場合は `@main` を，caller 自身で明示的に追従したい場合は `@v2`（major mutable，patch ごとに進む）または `@v2.2.0`（patch immutable）を pin する．`@v1` / `@v1.0.0` 系は self-detection bug により動作しないため利用しない．
 
 ### パターン (A)：tomio2480/github-workflows を直接参照
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ github-workflows/
 | アップデート（`@main`） | 中央 main へのマージで次回 PR から即反映 | 自分でフォーク先に上流同期すると反映 |
 | おすすめ対象 | Tomio さん本人 / ルールに異存がない利用者 | 組織運用 / ルールを独自カスタムしたい利用者 |
 
-参照先（`@` 以降）は caller workflow で選ぶ．既定は `@<SHA> # v2` 形式の SHA pin で，Dependabot が SHA とバージョンを自動追随する．即時反映を優先したい場合は `@main` を直接参照する．`@v1` / `@v1.0.0` 系は self-detection bug により動作しないため利用しない．
+参照先（`@` 以降）は caller workflow で選ぶ．既定は `@<SHA> # v2.2.0` 形式の SHA pin で，Dependabot が SHA と patch バージョンを自動追随する．即時反映を優先したい場合は `@main` を，caller 自身で明示的に追従したい場合は `@v2`（major mutable，patch ごとに進む）または `@v2.2.0`（patch immutable）を pin する．`@v1` / `@v1.0.0` 系は self-detection bug により動作しないため利用しない．
 
 ### パターン (A)：tomio2480/github-workflows を直接参照
 
@@ -124,7 +124,7 @@ curl -fsSL \
   > .github/workflows/md-lint.yml
 ```
 
-以後は自分のフォークを主軸に辞書やルールを育てていく．caller が `@main` を参照していれば自動で反映される．pinning したい利用者向けに `v1` / `v1.0.0` タグを打つのは任意．詳細は [docs/fork-usage.md](docs/fork-usage.md) を参照．
+以後は自分のフォークを主軸に辞書やルールを育てていく．caller が `@main` を参照していれば自動で反映される．pinning したい利用者向けに `vX.Y.Z` 形式の patch タグと `vX` の major mutable を打つのは任意．詳細は [docs/fork-usage.md](docs/fork-usage.md) を参照．
 
 ### 導入後の挙動
 
@@ -168,7 +168,8 @@ curl -fsSL \
 | ドキュメントの軽微な誤字修正 PR | AI で自動対応可 |
 | 設定ルールの無効化・変更 | ユーザー確認必須 |
 | 辞書（prh.yml）への追加 | AI が提案，ユーザー確認してマージ |
-| `@v1` タグの移動 | ユーザーのみ |
+| major mutable タグ（`v2` 等）の移動 | ユーザーのみ |
+| patch タグ（`v2.2.0` 等）の新規発行 | ユーザー確認のうえ AI が提案 |
 | 外部からの PR マージ | ユーザーのみ |
 | 中央 repo 自体の破壊的変更 | ユーザー確認必須かつ新バージョンタグが前提 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@
 対象リポジトリ（caller）
   │ .github/workflows/md-lint.yml が on: pull_request で起動
   │ 1. actions/checkout で caller 自身を checkout
-  │ 2. uses: OWNER/github-workflows/.github/actions/markdown-lint@<SHA> # v2
+  │ 2. uses: OWNER/github-workflows/.github/actions/markdown-lint@<SHA> # v2.2.0
   ▼
 composite action（本リポジトリ）
   │ 1. PR に 👀 reaction を付け「review 開始」を可視化（`pull_request` イベント時のみ）

--- a/docs/dictionary-maintenance.md
+++ b/docs/dictionary-maintenance.md
@@ -130,7 +130,7 @@ lint 上は両側スペース行で 1 件の diagnostic が出る．
 | `@main` | 中央 main へのマージで次回 PR から即反映．即時性重視の利用者向け |
 | `@v2` major mutable | patch リリースごとに最新 patch へ進められる．caller の介入なしで追従 |
 | `@v2.2.0` patch immutable | 原則反映されない（固定）．新 patch へ切り替える明示的な操作が必要 |
-| `@<SHA> # v2.2.0`（既定） | SHA pin．Dependabot が patch tag 更新を検知して caller に PR を起票 |
+| `@<SHA> # v2.2.0`（既定） | SHA pin．Dependabot がタグの更新を検知して caller に PR を起票 |
 
 patch リリースは PR マージごとに切る運用とする．major mutable は同時に最新 patch へ進める．
 
@@ -148,9 +148,9 @@ gh release create v2.2.1 --title "v2.2.1" --notes "..."
 | 変更種別 | タグ運用 |
 |---|---|
 | 辞書エントリ追加 | patch リリース（`vX.Y.Z+1`）として切る．major mutable も同時に進める |
-| 辞書エントリ削除・変更 | 既存 caller の指摘が意図せず変わるため事前に影響確認．patch として切るか minor に上げるかは破壊性で判断 |
-| prh 設定の構造変更 | minor リリース（`vX.Y+1.0`）として切る．major mutable も進める |
-| inputs の意味変更・required 化 | 後方非互換のため新 major（`vX+1`）を切る．旧 major は据え置き |
+| 辞書エントリ削除・変更 | 既存 caller の指摘が意図せず変わるため事前に影響確認．破壊性に応じて patch / minor のどちらで切るかを判断 |
+| prh.yml スキーマへの非破壊的追加 | minor リリース（`vX.Y+1.0`）として切る．major mutable も進める |
+| prh.yml スキーマの破壊的変更 / `action.yml` inputs の意味変更・required 化 | 後方非互換のため新 major（`vX+1`）を切る．旧 major は据え置き |
 
 破壊的変更の場合は CLAUDE.md のタグ運用規律に従う．
 

--- a/docs/dictionary-maintenance.md
+++ b/docs/dictionary-maintenance.md
@@ -2,7 +2,7 @@
 
 ## 要約
 
-表記ゆれ辞書 `prh.yml` は **中央リポジトリで一括管理** する．caller が `@main`（既定）を参照していれば，中央へのマージ時点で次回 PR から新辞書が効く．pinning 利用者（`@v1` / `@v1.0.0`）は対象タグが移動されるまで反映されない．個別リポジトリで辞書を独自運用したい場合のみ repo ローカルに `prh.yml` を置く（override）．
+表記ゆれ辞書 `prh.yml` は **中央リポジトリで一括管理** する．caller が `@main`（既定）を参照していれば，中央へのマージ時点で次回 PR から新辞書が効く．pinning 利用者（`@v2` major mutable / `@v2.2.0` のような patch immutable / SHA pin）は対象タグが移動・新規発行されるまで反映されない．個別リポジトリで辞書を独自運用したい場合のみ repo ローカルに `prh.yml` を置く（override）．
 
 ## 目次
 
@@ -43,7 +43,7 @@ git commit -m "dict: add XXX entry"
 
 Draft PR で `filter-mode: nofilter` で実際に lint を流し，辞書の想定通りの挙動を確認してから Ready にする．
 
-マージされると `@main` 参照の caller には次回 PR から新辞書が適用される．`@v1` / `@v1.0.0` pinning 利用者には反映されないため，pinning 利用者向けに反映したい場合は別途タグを移動する必要がある（後述）．
+マージされると `@main` 参照の caller には次回 PR から新辞書が適用される．`@v2` major mutable 利用者には patch tag を切って major mutable を進めたタイミングで反映される．`@v2.2.0` のような patch immutable 利用者は固定のため，新 patch（例: `@v2.2.1`）への明示的な切り替えが必要．SHA pin 利用者には Dependabot が更新 PR を起票する．詳細は後述．
 
 ## 2️⃣ per-repo の辞書 override
 
@@ -127,25 +127,30 @@ lint 上は両側スペース行で 1 件の diagnostic が出る．
 
 | caller の参照先 | 辞書変更が反映されるタイミング |
 |---|---|
-| `@main`（既定） | 中央 main へのマージで次回 PR から即反映 |
-| `@v1` | 中央が `v1` タグを移動したときのみ反映 |
-| `@v1.0.0` | 原則反映されない（固定） |
+| `@main` | 中央 main へのマージで次回 PR から即反映．即時性重視の利用者向け |
+| `@v2` major mutable | patch リリースごとに最新 patch へ進められる．caller の介入なしで追従 |
+| `@v2.2.0` patch immutable | 原則反映されない（固定）．新 patch へ切り替える明示的な操作が必要 |
+| `@<SHA> # v2.2.0`（既定） | SHA pin．Dependabot が patch tag 更新を検知して caller に PR を起票 |
 
-pinning 利用者（`@v1` / `@v1.0.0`）への反映が必要な変更を入れた場合はタグ運用を検討する．
+patch リリースは PR マージごとに切る運用とする．major mutable は同時に最新 patch へ進める．
 
 ```bash
-# v1 参照の利用者に最新 main を反映したい場合（要注意・事前通知必須）
-git tag -f v1 main
-git push -f origin v1
+# PR マージ後に patch tag を切り，major mutable を進める例
+git tag v2.2.1 <merge-sha>
+git push origin v2.2.1
+git tag -f v2 v2.2.1
+git push -f origin v2
+gh release create v2.2.1 --title "v2.2.1" --notes "..."
 ```
 
 表 3: 変更種別ごとの扱い
 
 | 変更種別 | タグ運用 |
 |---|---|
-| 辞書エントリ追加 | `@main` 利用者には即反映．pinning 利用者に反映したい場合のみ `v1` を移動 |
-| 辞書エントリ削除・変更 | `@main` 利用者の指摘が意図せず変わるため事前に影響確認．`v1` 移動は慎重に |
-| prh 設定の構造変更 | `v2` など新メジャーを切る．`v1` はそのまま維持 |
+| 辞書エントリ追加 | patch リリース（`vX.Y.Z+1`）として切る．major mutable も同時に進める |
+| 辞書エントリ削除・変更 | 既存 caller の指摘が意図せず変わるため事前に影響確認．patch として切るか minor に上げるかは破壊性で判断 |
+| prh 設定の構造変更 | minor リリース（`vX.Y+1.0`）として切る．major mutable も進める |
+| inputs の意味変更・required 化 | 後方非互換のため新 major（`vX+1`）を切る．旧 major は据え置き |
 
 破壊的変更の場合は CLAUDE.md のタグ運用規律に従う．
 

--- a/docs/fork-usage.md
+++ b/docs/fork-usage.md
@@ -98,12 +98,15 @@ git merge upstream/main
 main にマージされると `@main` 参照の caller には次回 PR から新しい内容が反映される．SHA pin 利用者は Dependabot の更新 PR を経由して取り込むため自動的に追随する．
 
 ```bash
-# pinning 利用者（@v2 のような major tag）にも反映したい場合（要注意・事前通知必須）
-git tag -f v2 main
+# patch リリース（PR マージごとに実施）
+git tag v2.2.1 main
+git push origin v2.2.1
+git tag -f v2 v2.2.1
 git push -f origin v2
+gh release create v2.2.1 --title "v2.2.1" --notes "..."
 ```
 
-`-f` と `--force` はオーナー操作．pinning 利用している caller の影響範囲を確認し，stakeholder（caller repo のオーナー）に事前通知したうえで実施する．パッチ追随を opt-in したい場合は `v2.x.y` のような追加タグを別 commit に切る運用が安全．
+`-f` と `--force` はオーナー操作．pinning 利用している caller の影響範囲を確認し，stakeholder（caller repo のオーナー）に事前通知したうえで実施する．patch immutable（`v2.2.0` 等）に固定したい caller は，新 patch への切り替えを明示的に行う必要がある．major mutable（`v2`）に追従する caller は patch リリースで自動的に最新化される．
 
 ## 5️⃣ 辞書・ルールの独自カスタム
 

--- a/docs/notes/2026-05-01-semver-release-operations.md
+++ b/docs/notes/2026-05-01-semver-release-operations.md
@@ -1,0 +1,48 @@
+# SemVer 風 patch タグ運用への移行
+
+## 背景
+
+中央 composite action のリリース運用で `v1` `v2` の major mutable タグだけが存在していた．
+patch tag を切る運用は未実行で，caller は `@main`（即時反映）か `@<SHA>`（固定）の二択しかなかった．
+さらに `v2` mutable は PR #4 のマージ位置から動かされていなかった．
+`@v2` pin 利用者は v2.1 の caller-side allowlist 以降の改善を受け取れない状態が続いていた．
+
+利用者が細かいバージョンアップの恩恵を受けられるよう，SemVer 風の patch tag 運用へ移行する．
+
+## 判断
+
+PR マージごとに `vX.Y.Z` patch タグを切る運用とする．major mutable（`v2`）は同時に最新 patch へ進める．caller は次の 4 形態から pin を選択できる．
+
+- `@main`：即時反映．即時性優先の利用者
+- `@v2` major mutable：PR マージごとに最新 patch へ自動追従．caller の介入なし
+- `@v2.2.0` patch immutable：固定．新 patch への切り替えは caller の明示操作
+- `@<SHA> # v2.2.0`：SHA pin．Dependabot が patch tag 更新を検知して PR 起票
+
+retroactive に v2.0.0 / v2.1.0 / v2.2.0 を切る．対応コミットは次のとおり．
+
+- v2.0.0：`8382b97`（PR #4 — composite action 移行の初出）
+- v2.1.0：`9d82865`（PR #17 — caller-side textlint allowlist 対応）
+- v2.2.0：`39b56da`（PR #23 — Issue #15 stage 2 prh ルール）
+
+`v2` mutable は v2.2.0 まで進める．
+
+中間 patch（v2.0.x の細分化など）は切らない．判定が難しく，必要な caller は SHA pin で固定可能．
+
+## 代替案と棄却理由
+
+1. **patch tag を切らない（現状維持）**
+   `@v2` mutable のみで運用する．caller の選択肢が二択（main か固定 SHA）になり，意図的な patch 追随が困難になる．SHA pin と Dependabot の組合せでは「patch だけ取りたい」「minor 以上は手動レビューしたい」のような細粒度制御ができない．現状の不便を放置するため棄却した．
+
+2. **過去の commit 全てに patch tag を割り当てる**
+   v2.0.1 / v2.0.2 / ... のように細かく区切る．判定が判断依存で運用負荷が高い．fix と内部リファクタの境界判定が難しい．caller への利益も限定的．代表的な節目（PR #17 = v2.1.0）のみで足りるため棄却した．
+
+3. **`v1` 系も patch tag を切る**
+   `v1` は self-detection bug で動作しないため使われていない．patch tag を打つ意味が無く棄却した．
+
+## 参照
+
+- [docs/dictionary-maintenance.md](../dictionary-maintenance.md) — 表 2／表 3 の参照方式・変更種別マトリクス
+- [CLAUDE.md](../../CLAUDE.md) — タグ運用規律（PR マージごとの patch リリース・major mutable 追従）
+- [docs/setup-guide.md](../setup-guide.md) — リリース時のコマンド例
+- [docs/fork-usage.md](../fork-usage.md) — フォーク利用者向けの patch リリース手順
+- [SemVer 2.0.0](https://semver.org/lang/ja/) — バージョン番号の意味づけ

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -85,7 +85,7 @@ gh release create v2 \
   --notes "Initial stable release as composite action."
 ```
 
-`@<SHA> # v2` 参照の利用者は SHA pin で固定されているので，タグを移動しても自動で SHA は変わらない．Dependabot の更新 PR を経由する．パッチ追随を opt-in したい場合は `v2.x.y` のような追加タグを別 commit に切る運用が安全．
+`@<SHA> # v2.x.y` 参照の利用者は SHA pin で固定されているので，タグを移動しても自動で SHA は変わらない．Dependabot の更新 PR を経由する．patch tag は PR マージごとに切る運用とし，major mutable（`v2`）も同時に最新 patch へ進める．caller は `@v2` で major mutable に追従するか，`@v2.2.0` のような patch immutable で固定するかを選べる．
 
 > [!WARNING]
 > `v1` タグは reusable workflow 形式で self-detection bug により動作しません．新規セットアップで `v1` を打ち直してはいけません．composite action 形式の v2 以降を採用してください．

--- a/templates/.github/workflows/md-lint.yml
+++ b/templates/.github/workflows/md-lint.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Markdown Lint via composite action
-        uses: OWNER/github-workflows/.github/actions/markdown-lint@<SHA> # v2
+        uses: OWNER/github-workflows/.github/actions/markdown-lint@<SHA> # v2.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # 必要に応じて inputs で上書き可能．詳細は中央リポジトリの README を参照．


### PR DESCRIPTION
## 概要

中央 composite action のリリース運用を **PR マージごとに `vX.Y.Z` patch タグを切る** 方針へ変更する．major mutable（`v2`）も同時に最新 patch へ進める．caller が `@v2` / `@v2.2.0` / `@<SHA>` から選べるようにする．

セルフレビュー実施済み（`self-reviewer` 一次走査で critical/major なし）．

## 背景

- 既存の `v2` mutable は PR #4 のマージ位置から動かされておらず，`@v2` pin 利用者は v2.1（caller-side allowlist）以降の改善を受け取れていなかった
- 規律自体は CLAUDE.md / dictionary-maintenance.md に「opt-in で v2.x.y を切る」 と部分的に文書化されていたが，運用は未実行だった
- caller の選択肢が `@main`（即時反映）と `@<SHA>`（固定）の二択で，中間の細粒度制御ができなかった

## 変更内容

### policy 文書

- `CLAUDE.md` — テンプレート・設定ファイル変更節のタグ運用規律を更新．major mutable は patch リリースごとに追従する旨を明記
- `docs/dictionary-maintenance.md` — 表 2 を 4 形態（main / major mutable / patch immutable / SHA pin）に拡張．表 3 を SemVer 区分（patch / minor / major）に合わせて再整理．patch リリースのコマンド例を追加
- `docs/setup-guide.md` / `docs/fork-usage.md` — opt-in 表現を運用既定の表現に変更．patch リリース手順を `git tag → push → tag -f → push -f → gh release create` の手順で明記
- `README.md` — SHA pin の version comment 例を `# v2.2.0` 形式に．Quick Start の参照先選択肢から壊れている `@v1` 系を取り除き，`@v2`（major mutable）/`@v2.2.0`（patch immutable）に置き換え．「v1 タグの移動」 だった判断主体行を「major mutable タグの移動」 と「patch タグの新規発行」 の 2 行に分割

### 知見メモ

- `docs/notes/2026-05-01-semver-release-operations.md`（新規）— 判断ログ．retroactive タグ位置（v2.0.0=`8382b97` / v2.1.0=`9d82865` / v2.2.0=`39b56da`）の根拠と代替案 3 件の棄却理由を保存

## 本 PR の範囲外（マージ後に別タスクで実施）

- 実際のタグ発行：`git tag v2.0.0 8382b97 && git tag v2.1.0 9d82865 && git tag v2.2.0 39b56da && git tag -f v2 39b56da` および対応する `git push` / `git push -f`
- GitHub Release 作成：v2.0.0 / v2.1.0 / v2.2.0 の 3 リリースに変更内容のサマリを添える

ドキュメント変更とタグ移動を分離するのは，docs PR のレビューと実タグ発行（caller への破壊的影響を伴う force-push）を独立させるため．

## 検証

- ローカル textlint：notes ファイル 0 problems，他 5 ファイルは pre-existing 違反のみで baseline と同件数
- pytest：42 件 pass（policy 変更で test に影響なし）
- 章番号・表番号：dictionary-maintenance.md 表 2/3 と既存表番号の整合維持

## Test plan

- [ ] CI `unit-python` job が 42 件 pass
- [ ] CI `unit-bash` job が green
- [ ] CI `integration-action` job がドキュメント PR で正常に走る
- [ ] reviewdog による誤検出なし
- [ ] CodeRabbit / Gemini Code Assist のレビュー指摘の反映

## チェックリスト

- [x] セルフコードレビュー実施済み（`self-reviewer` 一次走査）
- [x] CLAUDE.md / Skill 規律に従って Draft で起票
- [x] 既存の表番号・章番号と整合
- [ ] doc-syncer による Ready 直前チェック（CI 結果反映後に実施）