### PR TITLE
chore(action): actions/setup-node を v6.4.0 に bump して Node.js 24 ランタイムに対応する

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -127,8 +127,8 @@ runs:
         echo "config=${DEST}" >> "${GITHUB_OUTPUT}"
 
     - name: Setup Node.js
-      # actions/setup-node v4.4.0
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      # actions/setup-node v6.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: ${{ inputs.node-version }}
 


### PR DESCRIPTION
## セルフレビュー実施済み

指摘事項なし（2 行変更・SHA と版数コメントの対応を API で照合済み）．

## 概要

CI で出ていた Node.js 20 deprecation 警告を解消する．

- `actions/setup-node` v4.4.0 → v6.4.0
- SHA: `49933ea5288caeca8642d1e84afbd3f7d6820020` → `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`

## 変更内容

`.github/actions/markdown-lint/action.yml` の Setup Node.js ステップのみ変更．

変更前:
```yaml
# actions/setup-node v4.4.0
uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
```

変更後:
```yaml
# actions/setup-node v6.4.0
uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
```

## caller への影響

なし．`node-version` input のデフォルト（`"24"`）は変更なし．変更はアクション自身の JavaScript ランタイム（Node.js 20 → 24）のみ．

## v6.4.0 を選んだ理由

- Node.js 24 ランタイムは v5.0.0（2025-09-04）で初対応
- v6.4.0 は 2026-04-20 時点の最新リリース
- Dependabot が github-actions エコシステムを週次追跡しているため，自動 PR がなければ手動 bump を先行させる方針（Issue #42 に記載）

## 期限

- 2026-06-02：Node.js 24 がデフォルト強制（`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` 相当）
- 2026-09-16：Node.js 20 ランナーから削除

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * ビルドパイプラインの依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->