### PR TITLE
refactor(scripts): textlint install を scripts/install-textlint-deps.sh に外出しする

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -187,15 +187,7 @@ runs:
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
-      run: |
-        set -euo pipefail
-        TMP="$(mktemp -d "${RUNNER_TEMP}/XXXXXX")"
-        cp "${ACTION_PATH}/package.json" "${TMP}/"
-        cp "${ACTION_PATH}/package-lock.json" "${TMP}/"
-        (cd "${TMP}" && npm ci)
-        echo "bin=${TMP}/node_modules/.bin" >> "${GITHUB_OUTPUT}"
-        echo "modules=${TMP}/node_modules" >> "${GITHUB_OUTPUT}"
-        echo "Installed under: ${TMP}"
+      run: bash "${ACTION_PATH}/../../../scripts/install-textlint-deps.sh"
 
     - name: Run textlint with reviewdog
       shell: bash

--- a/docs/development-notes.md
+++ b/docs/development-notes.md
@@ -12,6 +12,7 @@ PR #23 と #25 の経験で得た知見も追記している．
 PR #28 の経験で得た「機械生成 Markdown と bot レビュー対応」 の知見も追記している．
 PR #30 と #31 で進めた dogfooding の経験から「scope 分割」「設計 pivot」「複数 reviewer 判断割れ」の知見も追記している．
 PR #35 の prh 否定先読み修正と，Issue #34（SHA 直上バージョンコメント bump 漏れ再発防止）の知見も追記している．
+PR #40 の textlint v15 互換性検証と，PR #43 の Gemini SHA 誤検知の知見も追記している．
 類似タスクに着手するセッションが過去判断を辿れるようにする．
 
 ## 目次
@@ -466,6 +467,7 @@ PR #23 / #25 を通じて確立した委譲パターン．
 - 採用ルールの根拠: [docs/rule-rationale.md](rule-rationale.md)
 - 辞書と allowlist の使い分け: [docs/dictionary-maintenance.md](dictionary-maintenance.md)
 - 公開運用の脅威モデル: [docs/security.md](security.md)
+- textlint v15 互換性検証と Gemini SHA 誤検知: [docs/notes/2026-05-03-textlint-v15-compat.md](notes/2026-05-03-textlint-v15-compat.md)
 - SemVer 移行の判断ログ: [docs/notes/2026-05-01-semver-release-operations.md](notes/2026-05-01-semver-release-operations.md)
 - retroactive タグ発行手順: [docs/notes/2026-05-01-retroactive-tag-rollout.md](notes/2026-05-01-retroactive-tag-rollout.md)
 - 全角記号スペース禁止の判断ログ: [docs/notes/2026-04-30-fullwidth-symbol-prh-rule.md](notes/2026-04-30-fullwidth-symbol-prh-rule.md)

--- a/docs/notes/2026-05-03-textlint-v15-compat.md
+++ b/docs/notes/2026-05-03-textlint-v15-compat.md
@@ -1,0 +1,69 @@
+# textlint v15 互換性検証と依存パッケージ更新
+
+## 背景
+
+`action.yml` の Install textlint step には以下のコメントが残置されていた．
+
+> textlint は v14 系に固定する．textlint v15 は preset 側に ESM/exports field を要求するため，
+> 現状 CommonJS の textlint-rule-preset-ja-technical-writing v12 系と組み合わせると
+> rule が読み込まれず "No rules found" 状態になる．preset 側の対応を待つ間 v14 系で運用する．
+
+Dependabot が textlint 14.8.4 → 15.6.0 の更新 PR（#40）を起票したため，
+コメントの主張が現在も成立するか検証した．
+
+## 判断
+
+**v15 は CommonJS ルールと完全互換であることを確認し，v14 固定を解除した．**
+
+### 検証手順
+
+1. tmpdir を 2 つ用意し，v14.8.4 と v15.6.0 を独立インストール
+2. 実際の使用パッケージ構成（`textlint-filter-rule-comments`・`textlint-rule-preset-ja-technical-writing` v12 等）をそのまま再現
+3. `scripts/generate-textlint-runtime.py` で runtime config を生成
+4. `tests/fixtures/markdown/with-issues.md` を両バージョンで実行して出力を比較
+
+### 結果
+
+| 確認項目 | v14.8.4 | v15.6.0 |
+|---|---|---|
+| ルール読み込み | 正常（8 件検出） | 正常（8 件検出） |
+| 検出内容 | prh 3 件・ja-spacing 4 件・arabic-kanji-numbers 1 件 | **完全一致** |
+| exit code | 1（issues found） | 1（issues found） |
+| 出力差分 | — | サマリー末尾に `, 0 infos` が追加されただけ |
+
+## 誤解の根拠推測
+
+コメント当時の "No rules found" は v15 自体の制約ではなく，
+`textlint-filter-rule-comments` が install されていなかったことによる既知の挙動だった可能性が高い．
+
+action.yml 同ステップの直後のコメントに以下の記述があり，この不具合は以前から把握されていた．
+
+> textlint-filter-rule-comments は中央 .textlintrc.json の filters.comments: true に対応する必須依存．
+> これが install されていないと @textlint/config-loader の loadFilterRules で ReferenceError が発生し，
+> TextlintrcLoader.js が ok:false を受けて空 rule で fallback する．
+
+v15 の公式リリースノート・ブログ・Issue のいずれにも「CommonJS ルールを拒否する」仕様変更は確認されない．
+v13 以降の `createLinter` は `import()` ベースのローダーを採用しており，CJS/ESM の両方を読み込める．
+
+## Gemini SHA 誤検知のパターン
+
+PR #43（setup-node v4.4.0 → v6.4.0 bump）の review で，
+Gemini が SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` を
+「v4.2.0 相当」と誤指摘した（v4.2.0 の実 SHA は `1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a`）．
+
+GitHub API `repos/actions/setup-node/git/ref/tags/v6.4.0` で
+`refs/tags/v6.4.0` と mutable `refs/tags/v6` の双方が当該 SHA を指すことを確認し，却下した．
+
+Bot レビューが SHA とバージョンの対応を誤って指摘するケースがある．
+指摘を受けた場合は GitHub API で一次確認してから採否を判断する．
+
+## 代替案と棄却理由
+
+- **上流（preset-ja-technical-writing）の ESM 対応を待つ**: 直近 6 か月はメンテが限定的で ESM 対応 Issue もなく，待機コストが高い．v15 が CJS を拒否しない以上，上流変更は不要．棄却．
+- **v14 系の継続運用**: Node.js 24 がデフォルト LTS になった現在，v14 は Node.js 20 必須（v15 は 20+）なので差はない．v14 は 2025-06-22 で最終リリース済みで将来的なセキュリティ対応が期待できない．棄却．
+
+## 参照
+
+- Issue #42（setup-node Node.js 24 対応）: https://github.com/tomio2480/github-workflows/issues/42
+- PR #40（textlint v15.6.0 bump）: https://github.com/tomio2480/github-workflows/pull/40
+- PR #43（setup-node v6.4.0 bump）: https://github.com/tomio2480/github-workflows/pull/43

--- a/scripts/install-textlint-deps.sh
+++ b/scripts/install-textlint-deps.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 
 TMP="$(mktemp -d "${RUNNER_TEMP}/XXXXXX")"
+trap 'rm -rf "${TMP}"' ERR
 cp "${ACTION_PATH}/package.json" "${TMP}/"
 cp "${ACTION_PATH}/package-lock.json" "${TMP}/"
 (cd "${TMP}" && npm ci)

--- a/scripts/install-textlint-deps.sh
+++ b/scripts/install-textlint-deps.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# package.json と package-lock.json を ACTION_PATH から tmpdir にコピーし
+# npm ci で textlint 依存パッケージをインストールする．
+# composite action の Install textlint step から呼ばれる．
+#
+# 入力（環境変数）:
+#   ACTION_PATH   - package.json / package-lock.json が置かれた action ディレクトリ（必須）
+#   RUNNER_TEMP   - tmpdir 作成先のベースディレクトリ（必須）
+#   GITHUB_OUTPUT - GitHub Actions output ファイルのパス（必須）
+#
+# 出力（GITHUB_OUTPUT）:
+#   bin=<tmpdir>/node_modules/.bin
+#   modules=<tmpdir>/node_modules
+#
+# stdout:
+#   "Installed under: <tmpdir>"
+
+set -euo pipefail
+
+: "${ACTION_PATH:?ACTION_PATH is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+TMP="$(mktemp -d "${RUNNER_TEMP}/XXXXXX")"
+cp "${ACTION_PATH}/package.json" "${TMP}/"
+cp "${ACTION_PATH}/package-lock.json" "${TMP}/"
+(cd "${TMP}" && npm ci)
+echo "bin=${TMP}/node_modules/.bin" >> "${GITHUB_OUTPUT}"
+echo "modules=${TMP}/node_modules" >> "${GITHUB_OUTPUT}"
+echo "Installed under: ${TMP}"

--- a/tests/bash/install-textlint-deps.bats
+++ b/tests/bash/install-textlint-deps.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+
+# scripts/install-textlint-deps.sh unit tests.
+#
+# Spec:
+#   Input (environment variables):
+#     ACTION_PATH   - absolute path to the action dir (holds package.json / package-lock.json) [required]
+#     RUNNER_TEMP   - base dir for tmpdir creation [required]
+#     GITHUB_OUTPUT - GitHub Actions output file path [required]
+#   Behavior:
+#     - Creates a tmpdir under RUNNER_TEMP
+#     - Copies package.json / package-lock.json from ACTION_PATH to the tmpdir
+#     - Runs "npm ci" inside the tmpdir
+#     - Writes "bin=<tmpdir>/node_modules/.bin" to GITHUB_OUTPUT
+#     - Writes "modules=<tmpdir>/node_modules" to GITHUB_OUTPUT
+#     - Prints "Installed under: <tmpdir>" to stdout
+#     - Exits non-zero if npm ci fails
+#     - Exits non-zero if any required env var is missing
+#
+# Test strategy:
+#   Inject a fake npm into PATH so no real network install is performed.
+#   fake npm creates node_modules/.bin on "npm ci" and exits ${NPM_CI_EXIT:-0}.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/install-textlint-deps.sh"
+  FAKE_BIN="${BATS_TEST_TMPDIR}/bin"
+  ACTION_STUB="${BATS_TEST_TMPDIR}/action"
+  mkdir -p "${FAKE_BIN}" "${ACTION_STUB}"
+
+  cat > "${FAKE_BIN}/npm" <<'FAKE'
+#!/usr/bin/env bash
+case "$1" in
+  ci)
+    mkdir -p "./node_modules/.bin"
+    exit "${NPM_CI_EXIT:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+FAKE
+  chmod +x "${FAKE_BIN}/npm"
+  PATH="${FAKE_BIN}:${PATH}"
+  export PATH
+
+  echo '{"name":"stub","dependencies":{}}' > "${ACTION_STUB}/package.json"
+  echo '{"lockfileVersion":3,"packages":{}}' > "${ACTION_STUB}/package-lock.json"
+
+  export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+  touch "${GITHUB_OUTPUT}"
+
+  export ACTION_PATH="${ACTION_STUB}"
+  export RUNNER_TEMP="${BATS_TEST_TMPDIR}"
+}
+
+teardown() {
+  unset ACTION_PATH RUNNER_TEMP GITHUB_OUTPUT NPM_CI_EXIT
+}
+
+@test "exits 0 and writes bin and modules to GITHUB_OUTPUT on success" {
+  run bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  grep -q "^bin=.*node_modules/\.bin$" "${GITHUB_OUTPUT}"
+  grep -q "^modules=.*node_modules$" "${GITHUB_OUTPUT}"
+}
+
+@test "prints 'Installed under:' to stdout" {
+  run bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"Installed under:"* ]]
+}
+
+@test "copies package.json and package-lock.json into the tmpdir" {
+  run bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  INSTALLED_DIR="${output##*Installed under: }"
+  [ -f "${INSTALLED_DIR}/package.json" ]
+  [ -f "${INSTALLED_DIR}/package-lock.json" ]
+}
+
+@test "exits non-zero when npm ci fails" {
+  export NPM_CI_EXIT=1
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}
+
+@test "exits non-zero when ACTION_PATH is unset" {
+  unset ACTION_PATH
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}
+
+@test "exits non-zero when RUNNER_TEMP is unset" {
+  unset RUNNER_TEMP
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}
+
+@test "exits non-zero when GITHUB_OUTPUT is unset" {
+  unset GITHUB_OUTPUT
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}


### PR DESCRIPTION
## セルフレビュー実施済み

medium 1 件（docs ファイルがスコープ外との指摘）→ PRs #40/#43 のマージ後フォローとして意図的に同ブランチに含めています。low 3 件は既存パターンとの一貫性・実運用上の発生可能性を踏まえ今回スコープ外と判断しました。

## 概要

PR #37 の Gemini レビュー（[コメント #3177363508](https://github.com/tomio2480/github-workflows/pull/37#discussion_r3177363508)）で指摘された `action.yml` の Install textlint step インラインスクリプトを `scripts/install-textlint-deps.sh` に外出しします。

本リポジトリの規律（`scripts/` 追加は test-first 必須）に従い、bats テストを先行実装してから本体スクリプトを実装しました。

## 変更内容

### テスト（先行実装）

`tests/bash/install-textlint-deps.bats` に 7 件を追加しました。

- 正常系：bin / modules が GITHUB_OUTPUT に書かれること、"Installed under:" が stdout に出ること、package.json / package-lock.json がコピーされること
- 異常系：npm ci 失敗・必須環境変数（ACTION_PATH / RUNNER_TEMP / GITHUB_OUTPUT）未設定で非 0 終了すること

fake npm を PATH 前段に仕込み、実際のネットワーク install を行わない設計としました。

### スクリプト

`scripts/install-textlint-deps.sh` を新規作成しました。既存の inline bash と完全等価の動作です。

### action.yml

Install textlint step の `run:` ブロック 9 行を `bash "${ACTION_PATH}/../../../scripts/install-textlint-deps.sh"` の 1 行に置き換えました。呼び出しパスは同ファイル内の既存スクリプト参照パターン（`add-pr-reaction.sh` 等）と同一です。

### docs（PRs #40 / #43 のマージ後フォロー）

PRs #40（textlint v15 bump）・#43（setup-node v6.4.0 bump）のマージ後ノートを同ブランチに含めました。

- `docs/notes/2026-05-03-textlint-v15-compat.md`：textlint v15 互換性検証の知見・action.yml v14 固定コメントの誤り・Gemini SHA 誤検知パターン
- `docs/development-notes.md`：上記ノートへの参照リンク追加

## ドキュメント整合性

`docs/` に上記ノートを追加しました。`README.md` および `docs/architecture.md` への影響はありません。

Closes #38