### PR TITLE
docs(textlintrc): max-kanji-continuous-len の allow で固有名詞を除外できることを示す

### DIFF
--- a/docs/rule-rationale.md
+++ b/docs/rule-rationale.md
@@ -162,8 +162,9 @@ claude/agents/
 ```
 
 中央テンプレートは `"allow": []`（空リスト）を既定として定義する．
-固有名詞の例外は各 caller リポジトリで per-repo override として追加する運用とする．
-手順は [docs/onboarding-existing-repo.md](onboarding-existing-repo.md) を参照する．
+固有名詞の例外は各 caller リポジトリで per-repo の `.textlintrc.json` に追加する運用とする．
+caller-side の除外方針については
+[docs/dictionary-maintenance.md](dictionary-maintenance.md) の「5️⃣」節も参照する．
 
 ## 📚 参照
 

--- a/docs/rule-rationale.md
+++ b/docs/rule-rationale.md
@@ -13,6 +13,7 @@
 - 📦 prh の表記ゆれ辞書
 - 🧩 全角記号前後の半角スペース禁止の根拠
 - 🧩 文体使い分けと no-mix-dearu-desumasu
+- 🧩 max-kanji-continuous-len と固有名詞の例外
 - 📚 参照
 
 ## 🎯 採用方針
@@ -139,6 +140,30 @@ claude/agents/
 
 ファイル全体が対象外になるため，文体以外のルール（表記ゆれ・助詞重複など）も
 チェックされなくなる点に注意する．
+
+## 🧩 max-kanji-continuous-len と固有名詞の例外
+
+`max-kanji-continuous-len` は漢字が連続する文字数を制限するルールで，既定値は `max: 6` である．
+固有名詞など，意味を損なわずに分割できない語が誤検出される場合がある．
+`allow` オプションで例外を文字列配列として指定することで回避できる
+（[Issue #49](https://github.com/tomio2480/github-workflows/issues/49)）．
+
+```json
+{
+  "rules": {
+    "preset-ja-technical-writing": {
+      "max-kanji-continuous-len": {
+        "max": 6,
+        "allow": ["電子情報通信学会", "情報処理推進機構"]
+      }
+    }
+  }
+}
+```
+
+中央テンプレートは `"allow": []`（空リスト）を既定として定義する．
+固有名詞の例外は各 caller リポジトリで per-repo override として追加する運用とする．
+手順は [docs/onboarding-existing-repo.md](onboarding-existing-repo.md) を参照する．
 
 ## 📚 参照
 

--- a/templates/.textlintrc.json
+++ b/templates/.textlintrc.json
@@ -20,7 +20,8 @@
         "max": 80
       },
       "max-kanji-continuous-len": {
-        "max": 6
+        "max": 6,
+        "allow": []
       },
       "no-mix-dearu-desumasu": {
         "preferInHeader": "",


### PR DESCRIPTION
## セルフレビュー実施済み

## 概要

Issue #49 で報告された「漢字が連続する固有名詞を linter が誤検出する問題」に対応する．

`textlint-rule-max-kanji-continuous-len` は `allow` オプション（文字列配列）で
例外語彙を指定できることを確認した．
linter 側で例外対応が可能なため，中央テンプレートに `"allow": []` を追加して
per-repo 拡張の起点を明示し，運用方針を `docs/rule-rationale.md` に記述する．

Closes #49

## 変更内容

- `templates/.textlintrc.json`
  - `max-kanji-continuous-len` に `"allow": []`（空リスト）を追加
  - 空リストは既存動作と等価で，per-repo override での拡張を想定した定義
- `docs/rule-rationale.md`
  - 新節「🧩 max-kanji-continuous-len と固有名詞の例外」を追加
  - `allow` オプションの仕様・設定例・中央テンプレートの運用方針を記述
  - 目次に新節を追記

## 補足

Issue #49 は「linter 側での例外対応が難しければ `tomio2480/settings` へエスカレーション」
と記載していたが，`allow` オプションが使えるため本 PR で完結する．
`tomio2480/settings` への起票については不要と判断した（linter 側で解決できるため）．

## テスト計画

- [ ] `templates/.textlintrc.json` の変更が textlint の挙動に影響しないことを確認（空リストは no-op）
- [ ] `docs/rule-rationale.md` の新節が textlint（sentence-length・max-kanji 等）で lint エラーにならないことを CI で確認
- [ ] `.github/workflows/test-self-lint.yml` の CI が green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)