### PR TITLE
fix: lint summary を PR 差分ファイルのみに絞る

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -242,6 +242,42 @@ runs:
           -filter-mode="${RD_FILTER_MODE}" \
           < textlint-report.xml
 
+    - name: List PR diff files (for summary scoping)
+      # lint summary の集計対象を PR 差分ファイルのみに絞るための入力を
+      # 用意する（Issue #59: markdown-glob（既定 **/*.md）はリポジトリ全体を
+      # 走査するため，reviewdog の filter-mode（inline コメントのみを diff
+      # 行に絞る機構）と summary 集計の対象範囲が一致せず，diff に含まれない
+      # ファイルの指摘まで summary に出てしまっていた）．
+      #
+      # 取得失敗時は ::warning:: を出し非 0 終了する（scripts/list-pr-diff-files.sh
+      # 側の設計）．continue-on-error で吸収し，後続ステップでは
+      # steps.diff_files.outputs.path が空のまま渡らないため，summary は
+      # 従来どおりリポジトリ全体スコープにフォールバックする（fail-open）．
+      #
+      # ガード条件は「Post lint summary comment to PR」と揃える．
+      id: diff_files
+      if: |
+        always() &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        inputs.post-summary == 'true'
+      shell: bash
+      continue-on-error: true
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -uo pipefail
+        DIFF_FILES_PATH="$(pwd)/pr-diff-files.txt"
+        if bash "${ACTION_PATH}/../../../scripts/list-pr-diff-files.sh" > "${DIFF_FILES_PATH}"; then
+          echo "path=${DIFF_FILES_PATH}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "::warning::Failed to list PR diff files; lint summary falls back to repo-wide scope"
+          echo "path=" >> "${GITHUB_OUTPUT}"
+        fi
+
     - name: Post lint summary comment to PR
       # reviewdog の github-pr-review reporter は findings ゼロのとき何も投稿
       # しないため，PR 上で「lint が走ったが指摘なし」 と「workflow が起動して
@@ -276,6 +312,7 @@ runs:
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         MARKDOWN_IGNORE: ${{ inputs.markdown-ignore }}
+        DIFF_FILES_PATH: ${{ steps.diff_files.outputs.path }}
       run: |
         set -uo pipefail
         SUMMARY_JSON_PATH="$(pwd)/lint-summary.json"
@@ -287,8 +324,13 @@ runs:
             [ -n "$line" ] && IGNORE_ARGS+=(--ignore-glob "$line")
           done <<< "${MARKDOWN_IGNORE}"
         fi
+        DIFF_FILES_ARGS=()
+        if [ -n "${DIFF_FILES_PATH}" ]; then
+          DIFF_FILES_ARGS=(--diff-files-from "${DIFF_FILES_PATH}")
+        fi
         python3 "${ACTION_PATH}/../../../scripts/count-lint-findings.py" \
           textlint-report.xml markdownlint-report.txt \
-          ${IGNORE_ARGS[@]+"${IGNORE_ARGS[@]}"} > "${SUMMARY_JSON_PATH}"
+          ${IGNORE_ARGS[@]+"${IGNORE_ARGS[@]}"} \
+          ${DIFF_FILES_ARGS[@]+"${DIFF_FILES_ARGS[@]}"} > "${SUMMARY_JSON_PATH}"
         SUMMARY_JSON="${SUMMARY_JSON_PATH}" \
           bash "${ACTION_PATH}/../../../scripts/post-lint-summary.sh"

--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -270,7 +270,10 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         set -uo pipefail
-        DIFF_FILES_PATH="$(pwd)/pr-diff-files.txt"
+        # 後続の「Post lint summary comment to PR」ステップが読む cross-step
+        # artifact のため，textlintrc.runtime.json と同じ規約で RUNNER_TEMP
+        # 配下に絶対パスで置く（caller cwd 非依存・ワークスペース非汚染）．
+        DIFF_FILES_PATH="${RUNNER_TEMP}/pr-diff-files.txt"
         if bash "${ACTION_PATH}/../../../scripts/list-pr-diff-files.sh" > "${DIFF_FILES_PATH}"; then
           echo "path=${DIFF_FILES_PATH}" >> "${GITHUB_OUTPUT}"
         else
@@ -315,7 +318,8 @@ runs:
         DIFF_FILES_PATH: ${{ steps.diff_files.outputs.path }}
       run: |
         set -uo pipefail
-        SUMMARY_JSON_PATH="$(pwd)/lint-summary.json"
+        # ワークスペース非汚染のため RUNNER_TEMP 配下に置く（pr-diff-files.txt と同じ規約）．
+        SUMMARY_JSON_PATH="${RUNNER_TEMP}/lint-summary.json"
         # markdown-ignore input が空でなければ改行区切りで複数 --ignore-glob を渡す．
         # 空行は無視．配列展開で空展開した場合に引数が落ちるよう ${arr[@]+...} を使う．
         IGNORE_ARGS=()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,8 +184,13 @@ reviewdog の `github-pr-review` reporter は findings ゼロのとき何も投�
 | fork PR | `pull-requests: write` が降格されるため事前に skip．reviewdog inline コメントの制約と整合 |
 | opt-out | composite action の `post-summary` input に `"false"` を渡せば投稿 step ごと skip．同一 PR で複数 job が同 marker を奪い合うケースの逃げ道．reviewdog の inline コメント投稿には影響しない |
 | 件数フィルタ | composite action の `markdown-ignore` input に path glob を改行区切りで渡すと summary 件数から除外できる．`tests/fixtures/**` のような prefix 形式で相対・絶対両方のパスを除外する．reviewdog の inline コメントは `filter-mode` で別途制御されるため本 input の影響を受けない |
+| 集計スコープ | summary は PR 差分ファイルのみを対象にする（[Issue #59](https://github.com/tomio2480/github-workflows/issues/59)）．取得失敗時はリポジトリ全体スコープにフォールバックする |
 
 集計と投稿は責務分離して 2 つのスクリプトで実装される．[scripts/count-lint-findings.py](../scripts/count-lint-findings.py) は textlint の checkstyle XML（`textlint-report.xml`）と markdownlint-cli2 のテキストレポート（`markdownlint-report.txt`）から件数と findings 一覧を集計し JSON を stdout に出す．[scripts/post-lint-summary.sh](../scripts/post-lint-summary.sh) はその JSON を本文化して PR コメントを upsert する．markdownlint 側の集計用に composite action 内で markdownlint-cli2 を 1 度再実行するため，reviewdog action と合わせて cli2 が 2 回走る．コストは数秒で軽微．将来的に reviewdog action を自前 `markdownlint-cli2 --reporter rdjson | reviewdog -f rdjson` に置き換えれば一本化できる．
+
+`markdown-glob`（既定 `**/*.md`）はリポジトリ全体を走査するため，textlint・markdownlint の実行結果自体はリポジトリ全体分の findings を含む．reviewdog の `filter-mode`（既定 `added`）は **inline コメント投稿のみ** を diff 行に絞る機構であり，summary 集計の対象範囲には影響しない．そのため対策前は「本 PR の差分ファイルは 1 件なのに summary は数百件」という事象が起きていた（Issue #59）．
+
+対策として，composite action に `List PR diff files (for summary scoping)` step を追加した．[scripts/list-pr-diff-files.sh](../scripts/list-pr-diff-files.sh) が `GET /repos/:owner/:repo/pulls/:pr/files` で PR の差分ファイル一覧を取得し，`count-lint-findings.py` の `--diff-files-from` にファイルパスとして渡す．これにより summary は PR 差分ファイルのみを対象にする．GitHub API 呼び出しが失敗した場合は `::warning::` を出しつつ `--diff-files-from` を渡さず，従来どおりリポジトリ全体スコープにフォールバックする（fail-open）．`--diff-files-from` は `count-lint-findings.py` 単体の後方互換のため未指定時は従来どおりリポジトリ全体を対象にする仕様のままである．
 
 reviewdog の `filter-mode: added`（既定）は PR 差分行に該当しない指摘を inline 化しない．このため「集計件数 N 件あるのに inline コメントが 0 件」 という見え方が起こりうる．この差を埋めるため summary コメントには以下を含める．
 

--- a/scripts/count-lint-findings.py
+++ b/scripts/count-lint-findings.py
@@ -109,10 +109,11 @@ def _is_in_diff_scope(path: str, diff_files: Sequence[str] | None) -> bool:
     """
     if diff_files is None:
         return True
+    # diff_files は呼び出し元（main()）で正規化済みの前提とする．
+    # ignore_globs / _is_ignored と同じ規約（要素側はループ内で再正規化しない）．
     norm_path = path.replace("\\", "/")
     for f in diff_files:
-        norm_f = f.replace("\\", "/")
-        if norm_path == norm_f or _path_matches_ignore(norm_path, norm_f + "/**"):
+        if norm_path == f or _path_matches_ignore(norm_path, f + "/**"):
             return True
     return False
 

--- a/scripts/count-lint-findings.py
+++ b/scripts/count-lint-findings.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import os
 import re
 import sys
 import xml.etree.ElementTree as ET
@@ -99,23 +100,32 @@ def _is_ignored(path: str, ignore_globs: Sequence[str] | None) -> bool:
     return any(_path_matches_ignore(norm_path, p) for p in ignore_globs)
 
 
+def _strip_workspace_prefix(norm_path: str) -> str:
+    """runner workspace（`GITHUB_WORKSPACE`）配下の絶対 path を相対 path に戻す．
+
+    post-lint-summary.sh の `normalize_file`（表示用の正規化）と同じ考え方．
+    `GITHUB_WORKSPACE` 未設定時（ローカル実行やテスト）はそのまま返す．
+    """
+    workspace = (os.environ.get("GITHUB_WORKSPACE") or "").replace("\\", "/").rstrip("/")
+    if workspace and norm_path.startswith(workspace + "/"):
+        return norm_path[len(workspace) + 1 :]
+    return norm_path
+
+
 def _is_in_diff_scope(path: str, diff_files: Sequence[str] | None) -> bool:
     """diff_files が None なら絞り込みなし（全 in-scope）．
 
-    リストが渡された場合（空リスト含む）は，各要素を `<file>/**` 相当の
-    prefix パターンとみなして `_path_matches_ignore` を再利用し，一致した
-    ものだけ in-scope とする．一致判定は ignore-glob と対称にすることで
-    絶対パス・相対パス両対応の挙動を揃える．
+    リストが渡された場合（空リスト含む）は，`GITHUB_WORKSPACE` prefix を
+    剥がした上での完全一致だけを in-scope とする．`_is_ignored` の
+    `<prefix>/**` サフィックス一致をそのまま流用すると，`docs/keep.md` が
+    無関係な `sub/docs/keep.md` にも一致してしまう誤判定を招くため，
+    diff_files（個別ファイル一覧）には流用しない．
     """
     if diff_files is None:
         return True
-    # diff_files は呼び出し元（main()）で正規化済みの前提とする．
-    # ignore_globs / _is_ignored と同じ規約（要素側はループ内で再正規化しない）．
-    norm_path = path.replace("\\", "/")
-    for f in diff_files:
-        if norm_path == f or _path_matches_ignore(norm_path, f + "/**"):
-            return True
-    return False
+    # diff_files は呼び出し元（main()）で正規化済み（\\ を / に）の前提とする．
+    rel_path = _strip_workspace_prefix(path.replace("\\", "/"))
+    return rel_path in diff_files
 
 
 def count_textlint(

--- a/scripts/count-lint-findings.py
+++ b/scripts/count-lint-findings.py
@@ -7,6 +7,7 @@ post-lint-summary.sh が担当する．
 
 usage:
     count-lint-findings.py <textlint-xml> <markdownlint-txt> [--ignore-glob PATTERN ...]
+        [--diff-files-from FILE]
 
 入力:
     <textlint-xml>     textlint の checkstyle 形式レポート
@@ -14,6 +15,11 @@ usage:
     --ignore-glob      集計から除外する path glob．繰り返し指定可．`tests/fixtures/**`
                        のような prefix 形式で，相対パス・絶対パス（runner workspace 配下）
                        両方の findings を除外する
+    --diff-files-from  PR 差分ファイル一覧（改行区切り）を書いたファイルパス．指定時は
+                       一覧外のファイルの findings を summary から除外する（Issue #59:
+                       reviewdog の filter-mode はリポジトリ全体走査の結果を絞り込まない
+                       ため，summary だけが diff 外まで報告していた事象への対応）．
+                       未指定時は従来どおりリポジトリ全体を対象にする
 
 出力（stdout，JSON）:
     {
@@ -93,7 +99,29 @@ def _is_ignored(path: str, ignore_globs: Sequence[str] | None) -> bool:
     return any(_path_matches_ignore(norm_path, p) for p in ignore_globs)
 
 
-def count_textlint(path: Path, ignore_globs: Sequence[str] | None = None) -> dict:
+def _is_in_diff_scope(path: str, diff_files: Sequence[str] | None) -> bool:
+    """diff_files が None なら絞り込みなし（全 in-scope）．
+
+    リストが渡された場合（空リスト含む）は，各要素を `<file>/**` 相当の
+    prefix パターンとみなして `_path_matches_ignore` を再利用し，一致した
+    ものだけ in-scope とする．一致判定は ignore-glob と対称にすることで
+    絶対パス・相対パス両対応の挙動を揃える．
+    """
+    if diff_files is None:
+        return True
+    norm_path = path.replace("\\", "/")
+    for f in diff_files:
+        norm_f = f.replace("\\", "/")
+        if norm_path == norm_f or _path_matches_ignore(norm_path, norm_f + "/**"):
+            return True
+    return False
+
+
+def count_textlint(
+    path: Path,
+    ignore_globs: Sequence[str] | None = None,
+    diff_files: Sequence[str] | None = None,
+) -> dict:
     """checkstyle XML を読み severity 別件数と findings 一覧を返す．"""
     empty = {"error": 0, "warning": 0, "info": 0, "total": 0, "findings": []}
     if not Path(path).is_file():
@@ -109,6 +137,8 @@ def count_textlint(path: Path, ignore_globs: Sequence[str] | None = None) -> dic
     for file_el in tree.getroot().iter("file"):
         file_name = file_el.get("name") or ""
         if _is_ignored(file_name, ignore_globs):
+            continue
+        if not _is_in_diff_scope(file_name, diff_files):
             continue
         for error in file_el.iter("error"):
             sev = (error.get("severity") or "").lower()
@@ -132,7 +162,11 @@ def count_textlint(path: Path, ignore_globs: Sequence[str] | None = None) -> dic
     return counts
 
 
-def count_markdownlint(path: Path, ignore_globs: Sequence[str] | None = None) -> dict:
+def count_markdownlint(
+    path: Path,
+    ignore_globs: Sequence[str] | None = None,
+    diff_files: Sequence[str] | None = None,
+) -> dict:
     """markdownlint-cli2 のテキストレポートから件数と findings 一覧を返す．"""
     if not Path(path).is_file():
         return {"total": 0, "findings": []}
@@ -145,6 +179,8 @@ def count_markdownlint(path: Path, ignore_globs: Sequence[str] | None = None) ->
                 continue
             file_name = m.group("file")
             if _is_ignored(file_name, ignore_globs):
+                continue
+            if not _is_in_diff_scope(file_name, diff_files):
                 continue
             try:
                 line_no = int(m.group("line"))
@@ -172,6 +208,15 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATTERN",
         help="path glob to exclude from findings; repeatable",
     )
+    parser.add_argument(
+        "--diff-files-from",
+        metavar="FILE",
+        help=(
+            "newline-separated list of PR diff files (relative paths); "
+            "when given, findings outside this list are excluded from the "
+            "summary. Omit to keep the legacy repo-wide scope (Issue #59)"
+        ),
+    )
     return parser
 
 
@@ -188,9 +233,21 @@ def main(argv: Sequence[str]) -> int:
             raise ValueError("--ignore-glob must not be empty or whitespace only")
         ignore_globs.append(normalized)
 
+    # --diff-files-from 未指定なら None（絞り込みなし = 従来挙動）．
+    # 指定されたファイルの空行は無視する．
+    diff_files: list[str] | None = None
+    if args.diff_files_from:
+        diff_files = [
+            line.strip().replace("\\", "/")
+            for line in Path(args.diff_files_from).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
     payload = {
-        "markdownlint": count_markdownlint(Path(args.markdownlint_txt), ignore_globs),
-        "textlint": count_textlint(Path(args.textlint_xml), ignore_globs),
+        "markdownlint": count_markdownlint(
+            Path(args.markdownlint_txt), ignore_globs, diff_files
+        ),
+        "textlint": count_textlint(Path(args.textlint_xml), ignore_globs, diff_files),
     }
     json.dump(payload, sys.stdout, ensure_ascii=False)
     sys.stdout.write("\n")

--- a/scripts/count-lint-findings.py
+++ b/scripts/count-lint-findings.py
@@ -58,7 +58,7 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Collection, Iterable, Sequence
 
 
 _MARKDOWNLINT_LINE = re.compile(
@@ -112,14 +112,19 @@ def _strip_workspace_prefix(norm_path: str) -> str:
     return norm_path
 
 
-def _is_in_diff_scope(path: str, diff_files: Sequence[str] | None) -> bool:
+def _is_in_diff_scope(path: str, diff_files: Collection[str] | None) -> bool:
     """diff_files が None なら絞り込みなし（全 in-scope）．
 
-    リストが渡された場合（空リスト含む）は，`GITHUB_WORKSPACE` prefix を
-    剥がした上での完全一致だけを in-scope とする．`_is_ignored` の
-    `<prefix>/**` サフィックス一致をそのまま流用すると，`docs/keep.md` が
-    無関係な `sub/docs/keep.md` にも一致してしまう誤判定を招くため，
-    diff_files（個別ファイル一覧）には流用しない．
+    渡された場合（空集合含む）は，`GITHUB_WORKSPACE` prefix を剥がした
+    上での完全一致だけを in-scope とする．`_is_ignored` の `<prefix>/**`
+    サフィックス一致をそのまま流用すると，`docs/keep.md` が無関係な
+    `sub/docs/keep.md` にも一致してしまう誤判定を招くため，diff_files
+    （個別ファイル一覧）には流用しない．
+
+    findings ごとに繰り返し呼ばれるため，diff_files には `in` が O(1) の
+    `set`（や `frozenset`）を渡すことを想定する．型ヒントを `Iterable` では
+    なく `Collection` にしているのは，一度きりの generator を渡すと 2 件目
+    以降の finding で必ず False になる事故を型で防ぐため．
     """
     if diff_files is None:
         return True
@@ -131,7 +136,7 @@ def _is_in_diff_scope(path: str, diff_files: Sequence[str] | None) -> bool:
 def count_textlint(
     path: Path,
     ignore_globs: Sequence[str] | None = None,
-    diff_files: Sequence[str] | None = None,
+    diff_files: Collection[str] | None = None,
 ) -> dict:
     """checkstyle XML を読み severity 別件数と findings 一覧を返す．"""
     empty = {"error": 0, "warning": 0, "info": 0, "total": 0, "findings": []}
@@ -176,7 +181,7 @@ def count_textlint(
 def count_markdownlint(
     path: Path,
     ignore_globs: Sequence[str] | None = None,
-    diff_files: Sequence[str] | None = None,
+    diff_files: Collection[str] | None = None,
 ) -> dict:
     """markdownlint-cli2 のテキストレポートから件数と findings 一覧を返す．"""
     if not Path(path).is_file():
@@ -245,14 +250,15 @@ def main(argv: Sequence[str]) -> int:
         ignore_globs.append(normalized)
 
     # --diff-files-from 未指定なら None（絞り込みなし = 従来挙動）．
-    # 指定されたファイルの空行は無視する．
-    diff_files: list[str] | None = None
+    # 指定されたファイルの空行は無視する．set にするのは findings ごとに
+    # 繰り返し呼ばれる _is_in_diff_scope の `in` 判定を O(1) にするため．
+    diff_files: set[str] | None = None
     if args.diff_files_from:
-        diff_files = [
+        diff_files = {
             line.strip().replace("\\", "/")
             for line in Path(args.diff_files_from).read_text(encoding="utf-8").splitlines()
             if line.strip()
-        ]
+        }
 
     payload = {
         "markdownlint": count_markdownlint(

--- a/scripts/list-pr-diff-files.sh
+++ b/scripts/list-pr-diff-files.sh
@@ -62,7 +62,12 @@ for item in payload:
 PY
 
   # Link ヘッダから rel="next" の URL を抽出する（post-lint-summary.sh と同じ実装）．
-  URL="$(grep -i '^link:' "${GET_HEADERS}" \
+  # `set -o pipefail` 下では次ページが無い（grep 不一致）とき pipeline の
+  # 終了コードが非 0 になり，ループ最後の代入がそのままスクリプト自身の
+  # 終了コードを汚染する．`|| true` で意図的に握りつぶす．
+  URL="$( (grep -i '^link:' "${GET_HEADERS}" \
     | sed -nE 's/.*<([^>]*)>;[[:space:]]*rel=["'"'"']next["'"'"'].*/\1/p' \
-    | head -n1)"
+    | head -n1) || true )"
 done
+
+exit 0

--- a/scripts/list-pr-diff-files.sh
+++ b/scripts/list-pr-diff-files.sh
@@ -49,7 +49,10 @@ while [ -n "${URL}" ]; do
     exit 1
   fi
 
-  python3 - "${GET_RESP}" <<'PY'
+  # `set -e` を使わない設計のため，JSON parse 失敗等の異常終了を明示的に
+  # 検知して非 0 で終わらせる．検知しないと「差分ファイル 0 件」と誤認され，
+  # 全指摘が summary から静かに消えるサイレント不具合になる．
+  python3 - "${GET_RESP}" <<'PY' || exit 1
 import json
 import sys
 

--- a/scripts/list-pr-diff-files.sh
+++ b/scripts/list-pr-diff-files.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# PR の差分ファイル一覧（filename）を 1 行 1 ファイルで stdout に出す．
+# lint summary（scripts/count-lint-findings.py の --diff-files-from）を
+# PR 差分ファイルのみに絞り込むための入力を作る（Issue #59）．
+#
+# 入力（環境変数）:
+#   GH_TOKEN  - GitHub token（必須）
+#   REPO      - owner/repo 形式のリポジトリ識別子（必須）
+#   PR_NUMBER - PR 番号（必須）
+#
+# 仕様:
+#   - GET /repos/:owner/:repo/pulls/:pr/files?per_page=100 を叩き，
+#     各要素の filename を stdout へ 1 行ずつ出す
+#   - Link ヘッダの rel="next" を辿り全ページを結合する（post-lint-summary.sh
+#     の pagination 実装と同じ方式）
+#   - 必須 env 不足は execution error として非 0 終了
+#   - GET 失敗（非 2xx）時は ::warning:: を出し非 0 終了する．呼び出し側
+#     （composite action）はこれを見て --diff-files-from を渡すのを諦め，
+#     従来どおりリポジトリ全体スコープにフォールバックする．「取得失敗」を
+#     「差分ファイル 0 件」として誤解釈させない（0 件のまま渡すと summary が
+#     全指摘を隠してしまう）ための fail-open 設計
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+GET_RESP="$(mktemp)"
+GET_HEADERS="$(mktemp)"
+trap 'rm -f "${GET_RESP}" "${GET_HEADERS}"' EXIT
+
+URL="https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100"
+while [ -n "${URL}" ]; do
+  : > "${GET_RESP}"
+  : > "${GET_HEADERS}"
+  GET_STATUS="$(
+    curl -sS --retry 2 --retry-all-errors --max-time 10 \
+      -o "${GET_RESP}" -D "${GET_HEADERS}" -w '%{http_code}' \
+      -H "Authorization: Bearer ${GH_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -X GET "${URL}"
+  )" || GET_STATUS="curl-error"
+
+  if ! [[ "${GET_STATUS}" =~ ^2[0-9][0-9]$ ]]; then
+    echo "::warning::Failed to list PR diff files (HTTP ${GET_STATUS})" >&2
+    [ -f "${GET_RESP}" ] && cat "${GET_RESP}" >&2 || true
+    exit 1
+  fi
+
+  python3 - "${GET_RESP}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    payload = json.load(f)
+for item in payload:
+    filename = item.get("filename")
+    if filename:
+        print(filename)
+PY
+
+  # Link ヘッダから rel="next" の URL を抽出する（post-lint-summary.sh と同じ実装）．
+  URL="$(grep -i '^link:' "${GET_HEADERS}" \
+    | sed -nE 's/.*<([^>]*)>;[[:space:]]*rel=["'"'"']next["'"'"'].*/\1/p' \
+    | head -n1)"
+done

--- a/tests/bash/list-pr-diff-files.bats
+++ b/tests/bash/list-pr-diff-files.bats
@@ -130,6 +130,17 @@ teardown() {
   [[ "${output}" == *"::warning::"* ]]
 }
 
+@test "GET は成功したが body が壊れた JSON のとき非 0 終了する（サイレント不具合防止）" {
+  # set -e を使わない設計のため，python3 の JSON parse 失敗を明示検知できていないと
+  # 「差分ファイル 0 件」として exit 0 してしまい，呼び出し側で全指摘が summary から
+  # 静かに消える．そのため execution error として非 0 終了することを保証する．
+  export FAKE_CURL_GET_BODY='not-json'
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}
+
 @test "GH_TOKEN 未設定で execution error として非 0 終了" {
   unset GH_TOKEN
 

--- a/tests/bash/list-pr-diff-files.bats
+++ b/tests/bash/list-pr-diff-files.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+
+# scripts/list-pr-diff-files.sh の単体テスト．
+#
+# 仕様:
+#   入力（環境変数）
+#     GH_TOKEN  - GitHub token（必須）
+#     REPO      - owner/repo（必須）
+#     PR_NUMBER - PR 番号（必須）
+#   動作
+#     - GET /repos/:owner/:repo/pulls/:pr/files?per_page=100 を叩き，
+#       各要素の filename を 1 行ずつ stdout に出す
+#     - Link ヘッダの rel="next" で全ページを辿る
+#     - 必須 env が欠ければ非 0 終了（execution error）
+#     - GET 失敗（非 2xx）時は ::warning:: を stderr に出し非 0 終了
+#       （Issue #59: 失敗時は「差分ファイル 0 件」と誤解釈させず，呼び出し側で
+#       repo-wide スコープへのフォールバック判断ができるようにするため）
+#
+# テスト戦略:
+#   post-lint-summary.bats と同様，実 API を叩かないため fake curl を
+#   PATH 前段に仕込む．
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/list-pr-diff-files.sh"
+
+  FAKE_BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "${FAKE_BIN}"
+  cat > "${FAKE_BIN}/curl" <<'FAKE'
+#!/usr/bin/env bash
+out_file=""
+hdr_file=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out_file="$2"; shift 2;;
+    -D) hdr_file="$2"; shift 2;;
+    -w) shift 2;;
+    -H) shift 2;;
+    --retry|--max-time) shift 2;;
+    -sS|--retry-all-errors) shift;;
+    http*) url="$1"; shift;;
+    *) shift;;
+  esac
+done
+
+if [ -n "${FAKE_CURL_LOG:-}" ]; then
+  printf 'GET %s\n' "${url}" >> "${FAKE_CURL_LOG}"
+fi
+
+counter_file="${FAKE_CURL_PAGE_COUNTER:-${BATS_TEST_TMPDIR}/page-counter}"
+n="$(cat "${counter_file}" 2>/dev/null || echo 0)"
+n=$((n + 1))
+echo "${n}" > "${counter_file}"
+
+body_var="FAKE_CURL_GET_BODY_PAGE_${n}"
+body="${!body_var:-${FAKE_CURL_GET_BODY:-[]}}"
+status="${FAKE_CURL_GET_STATUS:-200}"
+
+link_var="FAKE_CURL_GET_LINK_PAGE_${n}"
+link="${!link_var:-}"
+
+[ -n "${out_file}" ] && printf '%s' "${body}" > "${out_file}"
+if [ -n "${hdr_file}" ]; then
+  if [ -n "${link}" ]; then
+    printf 'HTTP/2 %s\r\nLink: %s\r\n\r\n' "${status}" "${link}" > "${hdr_file}"
+  else
+    printf 'HTTP/2 %s\r\n\r\n' "${status}" > "${hdr_file}"
+  fi
+fi
+printf '%s' "${status}"
+exit 0
+FAKE
+  chmod +x "${FAKE_BIN}/curl"
+  PATH="${FAKE_BIN}:${PATH}"
+  export PATH
+
+  export GH_TOKEN="fake-token"
+  export REPO="acme/repo"
+  export PR_NUMBER="42"
+  export FAKE_CURL_LOG="${BATS_TEST_TMPDIR}/curl.log"
+}
+
+teardown() {
+  unset GH_TOKEN REPO PR_NUMBER FAKE_CURL_LOG
+  unset FAKE_CURL_GET_STATUS FAKE_CURL_GET_BODY
+  unset FAKE_CURL_GET_BODY_PAGE_1 FAKE_CURL_GET_BODY_PAGE_2
+  unset FAKE_CURL_GET_LINK_PAGE_1 FAKE_CURL_GET_LINK_PAGE_2
+}
+
+@test "PR ファイル一覧を 1 行 1 ファイルで stdout に出す" {
+  export FAKE_CURL_GET_BODY='[{"filename":"docs/a.md"},{"filename":"docs/b.md"}]'
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "docs/a.md" ]
+  [ "${lines[1]}" = "docs/b.md" ]
+  grep -q '^GET https://api\.github\.com/repos/acme/repo/pulls/42/files' "${FAKE_CURL_LOG}"
+}
+
+@test "空配列のときは空出力で正常終了する" {
+  export FAKE_CURL_GET_BODY='[]'
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}
+
+@test "Link ヘッダ next で全ページを辿り filename を結合する" {
+  export FAKE_CURL_GET_BODY_PAGE_1='[{"filename":"a.md"}]'
+  export FAKE_CURL_GET_LINK_PAGE_1='<https://api.github.com/page2>; rel="next"'
+  export FAKE_CURL_GET_BODY_PAGE_2='[{"filename":"b.md"}]'
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "a.md" ]
+  [ "${lines[1]}" = "b.md" ]
+  [ "$(grep -c '^GET ' "${FAKE_CURL_LOG}")" -eq 2 ]
+}
+
+@test "GET 失敗時は ::warning:: を出し非 0 終了する" {
+  export FAKE_CURL_GET_STATUS=503
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"::warning::"* ]]
+}
+
+@test "GH_TOKEN 未設定で execution error として非 0 終了" {
+  unset GH_TOKEN
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}
+
+@test "REPO 未設定で execution error として非 0 終了" {
+  unset REPO
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}
+
+@test "PR_NUMBER 未設定で execution error として非 0 終了" {
+  unset PR_NUMBER
+
+  run bash "${SCRIPT}"
+
+  [ "${status}" -ne 0 ]
+}

--- a/tests/python/test_count_lint_findings.py
+++ b/tests/python/test_count_lint_findings.py
@@ -292,3 +292,93 @@ def test_main_accepts_repeated_ignore_glob(capsys):
     # markdownlint: docs/keep.md の 1 件のみ
     assert payload["markdownlint"]["total"] == 1
     assert payload["markdownlint"]["findings"][0]["file"] == "docs/keep.md"
+
+
+# ---- --diff-files-from (Issue #59: summary を PR 差分ファイルのみに絞る) ----
+
+def test_count_textlint_diff_files_scopes_to_listed_files():
+    # with-ignored-paths.xml は docs/keep.md（error 1件）と
+    # tests/fixtures/markdown/... 配下（warning 2 + info 1）を含む．
+    # diff_files に docs/keep.md のみを渡すと，それ以外は除外される．
+    result = _MODULE.count_textlint(
+        _FIXTURES / "textlint-reports" / "with-ignored-paths.xml",
+        diff_files=["docs/keep.md"],
+    )
+    assert result["total"] == 1
+    assert result["findings"][0]["file"] == "docs/keep.md"
+
+
+def test_count_textlint_diff_files_none_keeps_all_findings():
+    # diff_files 未指定（None）は従来どおり全 findings を返す．
+    full = _MODULE.count_textlint(
+        _FIXTURES / "textlint-reports" / "with-ignored-paths.xml"
+    )
+    scoped = _MODULE.count_textlint(
+        _FIXTURES / "textlint-reports" / "with-ignored-paths.xml",
+        diff_files=None,
+    )
+    assert full == scoped
+
+
+def test_count_textlint_diff_files_empty_list_excludes_everything():
+    # diff_files=[] は「差分ファイルが 0 件」を意味するため全除外する．
+    # None（絞り込みなし）と [] （0 件に絞り込み）は区別する．
+    result = _MODULE.count_textlint(
+        _FIXTURES / "textlint-reports" / "with-ignored-paths.xml",
+        diff_files=[],
+    )
+    assert result["total"] == 0
+    assert result["findings"] == []
+
+
+def test_count_textlint_diff_files_matches_absolute_paths_via_subpath():
+    result = _MODULE.count_textlint(
+        _FIXTURES / "textlint-reports" / "with-ignored-paths.xml",
+        diff_files=["tests/fixtures/markdown/another.md"],
+    )
+    files = [f["file"] for f in result["findings"]]
+    assert all("another.md" in f for f in files)
+    assert len(files) >= 1
+
+
+def test_count_markdownlint_diff_files_scopes_to_listed_files():
+    result = _MODULE.count_markdownlint(
+        _FIXTURES / "markdownlint-reports" / "with-ignored-paths.txt",
+        diff_files=["docs/keep.md"],
+    )
+    assert result["total"] == 1
+    assert result["findings"][0]["file"] == "docs/keep.md"
+
+
+def test_main_accepts_diff_files_from_file(capsys, tmp_path):
+    diff_list = tmp_path / "diff-files.txt"
+    diff_list.write_text("docs/keep.md\n\n", encoding="utf-8")
+    rc = _MODULE.main(
+        [
+            str(_FIXTURES / "textlint-reports" / "with-ignored-paths.xml"),
+            str(_FIXTURES / "markdownlint-reports" / "with-ignored-paths.txt"),
+            "--diff-files-from",
+            str(diff_list),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["textlint"]["total"] == 1
+    assert payload["textlint"]["findings"][0]["file"] == "docs/keep.md"
+    assert payload["markdownlint"]["total"] == 1
+    assert payload["markdownlint"]["findings"][0]["file"] == "docs/keep.md"
+
+
+def test_main_without_diff_files_from_keeps_all_findings(capsys):
+    # --diff-files-from 未指定時は従来どおりリポジトリ全体の findings を返す
+    # （後方互換：既存 caller の挙動を変えない）．
+    rc = _MODULE.main(
+        [
+            str(_FIXTURES / "textlint-reports" / "with-ignored-paths.xml"),
+            str(_FIXTURES / "markdownlint-reports" / "with-ignored-paths.txt"),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["textlint"]["total"] == 4
+    assert payload["markdownlint"]["total"] == 4

--- a/tests/python/test_count_lint_findings.py
+++ b/tests/python/test_count_lint_findings.py
@@ -331,14 +331,38 @@ def test_count_textlint_diff_files_empty_list_excludes_everything():
     assert result["findings"] == []
 
 
-def test_count_textlint_diff_files_matches_absolute_paths_via_subpath():
+def test_count_textlint_diff_files_matches_absolute_paths_via_workspace_strip(
+    monkeypatch,
+):
+    # with-ignored-paths.xml の 1 件は絶対パス
+    # /home/runner/work/repo/repo/tests/fixtures/markdown/another.md．
+    # GITHUB_WORKSPACE を設定すれば，その prefix を剥がした相対パスで
+    # diff_files と完全一致させられる．
+    monkeypatch.setenv("GITHUB_WORKSPACE", "/home/runner/work/repo/repo")
     result = _MODULE.count_textlint(
         _FIXTURES / "textlint-reports" / "with-ignored-paths.xml",
         diff_files=["tests/fixtures/markdown/another.md"],
     )
     files = [f["file"] for f in result["findings"]]
-    assert all("another.md" in f for f in files)
-    assert len(files) >= 1
+    assert len(files) == 1
+    assert files[0] == "/home/runner/work/repo/repo/tests/fixtures/markdown/another.md"
+
+
+def test_count_textlint_diff_files_rejects_false_positive_suffix_match(tmp_path):
+    # 差分ファイルが docs/keep.md のとき，末尾が一致するだけの無関係な
+    # sub/docs/keep.md を誤って in-scope にしてはいけない（サフィックス一致
+    # による誤判定の回帰防止）．
+    xml = tmp_path / "suffix.xml"
+    xml.write_text(
+        '<?xml version="1.0"?><checkstyle>'
+        '<file name="sub/docs/keep.md">'
+        '<error line="1" severity="error" message="m" source="r"/></file>'
+        "</checkstyle>",
+        encoding="utf-8",
+    )
+    result = _MODULE.count_textlint(xml, diff_files=["docs/keep.md"])
+    assert result["total"] == 0
+    assert result["findings"] == []
 
 
 def test_count_markdownlint_diff_files_scopes_to_listed_files():


### PR DESCRIPTION
## 概要

reviewdog の `filter-mode`（既定 `added`）は inline コメント投稿のみを diff 行に絞る機構であり，lint summary の集計自体は `markdown-glob`（既定 `**/*.md`）どおりリポジトリ全体を走査していた．このため PR の差分ファイルが 1 件でも，無関係な既存ファイルの指摘まで summary に含まれる事象があった．

## 変更内容

- `scripts/count-lint-findings.py` に `--diff-files-from` を追加し，指定したファイル一覧外の findings を集計から除外できるようにした．未指定時は従来どおりリポジトリ全体スコープ（後方互換）．
- `scripts/list-pr-diff-files.sh` を追加し，GitHub API から PR 差分ファイル一覧を取得する．取得失敗時は `::warning::` を出し非 0 終了し，呼び出し側でリポジトリ全体スコープへフォールバックできるようにした（fail-open）．
- `.github/actions/markdown-lint/action.yml` に diff ファイル一覧取得 step を追加し，summary 投稿 step に `--diff-files-from` を配線した．
- `docs/architecture.md` の lint summary 節に本対応を追記した．

## テスト

- `tests/python/test_count_lint_findings.py`：`--diff-files-from` の Red → Green を確認（`python -m pytest tests/python -q` で 81 件 pass）．
- `tests/bash/list-pr-diff-files.bats`：新規追加．ローカル環境に bats が無いため CI（`test-self-lint.yml`）での確認が必要．

## 動作確認

- 本 PR 自体で dogfooding される（`test-self-lint.yml`）ため，summary コメントが本 PR の差分ファイルのみに絞られることを実地で確認する．

Closes #59