### PR TITLE
chore: .claude/ を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules/
 .vscode/
 .idea/
 
+# Claude Code（ローカル権限設定・worktree 置き場．共有しない）
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## 要約

セルフレビュー実施済み．
未追跡の `.claude/` ディレクトリを `.gitignore` へ追加する．

## 背景

セッション中に `.claude/settings.json`（ローカル権限設定）と
`.claude/worktrees/`（セッションローカルな作業領域）が未追跡で残っていた．
`settings.json` はユーザー固有の絶対パスを含むため共有に適さない．
リポジトリ共有すべき Claude Code 設定が将来生じた場合は，
その時点で個別ファイル単位の追跡へ見直す．

## 変更内容

- `.gitignore` の Editor 節の後に `.claude/` を追加

## 確認事項

- 対応する Issue はない（軽微変更のため紐づけ不要）．
- ドキュメントへの影響なし（README・docs は `.claude/` に言及していない）．

🤖 Generated with [Claude Code](https://claude.com/claude-code)
